### PR TITLE
feat: add support for both ServiceWorkerWallet and Wallet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,46 @@ const arkadeLightning = new ArkadeLightning({
 });
 ```
 
+## Wallet class Compatibility
+
+This library supports both wallet interface patterns:
+
+### Wallet (with nested identity)
+
+```typescript
+import { Wallet } from '@arkade-os/sdk';
+
+const wallet = await Wallet.create({
+  identity,
+  arkServerUrl: 'https://mutinynet.arkade.sh',
+});
+
+// Wallet has built-in providers
+const arkadeLightning = new ArkadeLightning({
+  wallet,
+  swapProvider,
+});
+```
+
+### ServiceWorkerWallet (legacy interface)
+
+```typescript
+// ServiceWorkerWallet has identity methods spread directly
+const serviceWorkerWallet = new ServiceWorkerWallet(serviceWorker);
+await serviceWorkerWallet.init({
+  privateKey: 'your_private_key_hex',
+  arkServerUrl: 'https://ark.example.com'
+});
+
+// Must provide external providers for ServiceWorkerWallet
+const arkadeLightning = new ArkadeLightning({
+  wallet: serviceWorkerWallet,
+  arkProvider: new ArkProvider('https://ark.example.com'),
+  indexerProvider: new IndexerProvider('https://indexer.example.com'),
+  swapProvider,
+});
+```
+
 ## Storage
 
 By default this library doesn't store pending swaps.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const arkadeLightning = new ArkadeLightning({
 
 This library supports both wallet interface patterns:
 
-### Wallet (with nested identity)
+### Wallet (with optional nested identity and providers)
 
 ```typescript
 import { Wallet } from '@arkade-os/sdk';
@@ -64,24 +64,25 @@ const wallet = await Wallet.create({
   arkServerUrl: 'https://mutinynet.arkade.sh',
 });
 
-// Wallet has built-in providers
+// Wallet may have built-in providers
 const arkadeLightning = new ArkadeLightning({
   wallet,
   swapProvider,
+  // arkProvider and indexerProvider can be provided here if wallet doesn't have them
 });
 ```
 
 ### ServiceWorkerWallet (legacy interface)
 
 ```typescript
-// ServiceWorkerWallet has identity methods spread directly
+// ServiceWorkerWallet has identity methods spread directly (no nested identity)
 const serviceWorkerWallet = new ServiceWorkerWallet(serviceWorker);
 await serviceWorkerWallet.init({
   privateKey: 'your_private_key_hex',
   arkServerUrl: 'https://ark.example.com'
 });
 
-// Must provide external providers for ServiceWorkerWallet
+// Must provide external providers for ServiceWorkerWallet (it doesn't have them)
 const arkadeLightning = new ArkadeLightning({
   wallet: serviceWorkerWallet,
   arkProvider: new ArkProvider('https://ark.example.com'),

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ const arkadeLightning = new ArkadeLightning({
 ### ServiceWorkerWallet (legacy interface)
 
 ```typescript
+import { RestArkProvider, RestIndexerProvider } from '@arkade-os/sdk';
+
 // ServiceWorkerWallet has identity methods spread directly (no nested identity)
 const serviceWorkerWallet = new ServiceWorkerWallet(serviceWorker);
 await serviceWorkerWallet.init({
@@ -85,8 +87,8 @@ await serviceWorkerWallet.init({
 // Must provide external providers for ServiceWorkerWallet (it doesn't have them)
 const arkadeLightning = new ArkadeLightning({
   wallet: serviceWorkerWallet,
-  arkProvider: new ArkProvider('https://ark.example.com'),
-  indexerProvider: new IndexerProvider('https://indexer.example.com'),
+  arkProvider: new RestArkProvider('https://ark.example.com'),
+  indexerProvider: new RestIndexerProvider('https://indexer.example.com'),
   swapProvider,
 });
 ```

--- a/src/arkade-lightning.ts
+++ b/src/arkade-lightning.ts
@@ -82,12 +82,12 @@ export class ArkadeLightning {
     // Prioritize wallet providers, fallback to config providers for backward compatibility
     // Handle both cases: wallet.arkProvider doesn't exist OR wallet.arkProvider is undefined
     const walletArkProvider = config.wallet.arkProvider;
-    const arkProvider = (walletArkProvider && walletArkProvider) || config.arkProvider;
+    const arkProvider = walletArkProvider || config.arkProvider;
     if (!arkProvider) throw new Error('Ark provider is required either in wallet or config.');
     this.arkProvider = arkProvider;
     
     const walletIndexerProvider = config.wallet.indexerProvider;
-    const indexerProvider = (walletIndexerProvider && walletIndexerProvider) || config.indexerProvider;
+    const indexerProvider = walletIndexerProvider || config.indexerProvider;
     if (!indexerProvider) throw new Error('Indexer provider is required either in wallet or config.');
     this.indexerProvider = indexerProvider;
     

--- a/src/arkade-lightning.ts
+++ b/src/arkade-lightning.ts
@@ -48,7 +48,7 @@ import { decodeInvoice, getInvoicePaymentHash } from './utils/decoding';
 // Utility functions to handle both wallet types
 function getIdentity(wallet: Wallet): Identity {
   // Check if wallet has nested identity (new structure)
-  if ('identity' in wallet && wallet.identity) {
+  if (wallet.identity) {
     return wallet.identity;
   }
   // Otherwise assume it's a ServiceWorkerWallet with identity methods spread

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,21 @@ export interface Vtxo {
   };
 }
 
-export type Wallet = IWallet & {
+// Support both wallet interfaces:
+// 1. Wallet with nested identity (new structure)
+// 2. ServiceWorkerWallet with identity methods spread directly (legacy)
+export type WalletWithNestedIdentity = IWallet & {
   arkProvider: ArkProvider;
   indexerProvider: IndexerProvider;
   identity: Identity;
 };
+
+export type ServiceWorkerWallet = IWallet & Identity & {
+  arkProvider?: ArkProvider;
+  indexerProvider?: IndexerProvider;
+};
+
+export type Wallet = WalletWithNestedIdentity | ServiceWorkerWallet;
 
 export type Network = 'bitcoin' | 'mutinynet' | 'regtest' | 'testnet';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,13 +25,22 @@ export interface Vtxo {
 // Support both wallet interfaces:
 // 1. Wallet with optional nested identity and providers
 // 2. ServiceWorkerWallet with identity methods spread directly (legacy)
-export type Wallet = IWallet & {
+export type WalletWithNestedIdentity = IWallet & {
   arkProvider?: ArkProvider;
   indexerProvider?: IndexerProvider;
-  identity?: Identity;
+  identity: Identity;
 };
 
 export type ServiceWorkerWallet = IWallet & Identity;
+
+export type Wallet = WalletWithNestedIdentity | ServiceWorkerWallet;
+
+// Type guards for better ergonomics and type narrowing
+export const isWalletWithNestedIdentity = (w: Wallet): w is WalletWithNestedIdentity =>
+  !!(w as any).identity && typeof (w as any).identity?.xOnlyPublicKey === 'function';
+
+export const isServiceWorkerWallet = (w: Wallet): w is ServiceWorkerWallet =>
+  typeof (w as any).xOnlyPublicKey === 'function' && !(w as any).identity;
 
 export type Network = 'bitcoin' | 'mutinynet' | 'regtest' | 'testnet';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,20 +23,15 @@ export interface Vtxo {
 }
 
 // Support both wallet interfaces:
-// 1. Wallet with nested identity (new structure)
+// 1. Wallet with optional nested identity and providers
 // 2. ServiceWorkerWallet with identity methods spread directly (legacy)
-export type WalletWithNestedIdentity = IWallet & {
-  arkProvider: ArkProvider;
-  indexerProvider: IndexerProvider;
-  identity: Identity;
-};
-
-export type ServiceWorkerWallet = IWallet & Identity & {
+export type Wallet = IWallet & {
   arkProvider?: ArkProvider;
   indexerProvider?: IndexerProvider;
+  identity?: Identity;
 };
 
-export type Wallet = WalletWithNestedIdentity | ServiceWorkerWallet;
+export type ServiceWorkerWallet = IWallet & Identity;
 
 export type Network = 'bitcoin' | 'mutinynet' | 'regtest' | 'testnet';
 

--- a/tests/arkade-lightning.test.ts
+++ b/tests/arkade-lightning.test.ts
@@ -249,6 +249,47 @@ describe('ArkadeLightning', () => {
       expect(lightning.waitAndClaim).toBeInstanceOf(Function);
       expect(lightning.waitForSwapSettlement).toBeInstanceOf(Function);
     });
+
+    it('should work with ServiceWorkerWallet (legacy interface)', () => {
+      // Create a mock ServiceWorkerWallet that has identity methods spread directly
+      const mockServiceWorkerWallet = {
+        getAddress: vi.fn().mockResolvedValue(mock.address),
+        getBalance: vi.fn().mockResolvedValue(mock.invoice.amount),
+        getBoardingAddress: vi.fn().mockResolvedValue(mock.address),
+        getBoardingUtxos: vi.fn().mockResolvedValue([]),
+        getTransactionHistory: vi.fn().mockResolvedValue([]),
+        sendBitcoin: vi.fn().mockResolvedValue(mock.txid),
+        settle: vi.fn().mockResolvedValue(undefined),
+        getVtxos: vi.fn().mockResolvedValue([]),
+        // Identity methods spread directly (ServiceWorkerWallet pattern)
+        xOnlyPublicKey: vi.fn().mockReturnValue(mock.pubkeys.alice),
+        signerSession: vi.fn().mockReturnValue({
+          sign: vi.fn().mockResolvedValue({ txid: mock.txid, hex: mock.hex }),
+        }),
+        sign: vi.fn(),
+        // No arkProvider or indexerProvider (undefined)
+        arkProvider: undefined,
+        indexerProvider: undefined,
+      } as any;
+
+      // Should be able to create ArkadeLightning with external providers
+      expect(() => new ArkadeLightning({ 
+        wallet: mockServiceWorkerWallet, 
+        arkProvider, 
+        swapProvider, 
+        indexerProvider 
+      })).not.toThrow();
+    });
+
+    it('should work with WalletWithNestedIdentity (new interface)', () => {
+      // This is what mockWallet already is - with nested identity
+      expect(() => new ArkadeLightning({ 
+        wallet: mockWallet, 
+        arkProvider, 
+        swapProvider, 
+        indexerProvider 
+      })).not.toThrow();
+    });
   });
 
   describe('VHTLC Operations', () => {

--- a/tests/arkade-lightning.test.ts
+++ b/tests/arkade-lightning.test.ts
@@ -7,8 +7,15 @@ import {
   CreateSubmarineSwapRequest,
   CreateSubmarineSwapResponse,
 } from '../src/boltz-swap-provider';
-import type { PendingReverseSwap, PendingSubmarineSwap, Wallet } from '../src/types';
-import { RestArkProvider, RestIndexerProvider } from '@arkade-os/sdk';
+import type { 
+  PendingReverseSwap, 
+  PendingSubmarineSwap, 
+  Wallet, 
+  ServiceWorkerWallet,
+  ArkadeLightningConfig,
+  WalletWithNestedIdentity
+} from '../src/types';
+import { RestArkProvider, RestIndexerProvider, Identity, ArkInfo } from '@arkade-os/sdk';
 import { StorageProvider } from '../src';
 import { VHTLC } from '@arkade-os/sdk';
 import { hex } from '@scure/base';
@@ -210,7 +217,7 @@ describe('ArkadeLightning', () => {
           sign: vi.fn().mockResolvedValue({ txid: mock.txid, hex: mock.hex }),
         }),
         sign: vi.fn(),
-      } as any,
+      } satisfies Partial<Identity> as Identity,
     };
 
     // Basic mock swap provider
@@ -231,12 +238,12 @@ describe('ArkadeLightning', () => {
     });
 
     it('should fail to instantiate without required config', async () => {
-      const params = { wallet: mockWallet, swapProvider, arkProvider, indexerProvider } as any;
+      const params: ArkadeLightningConfig = { wallet: mockWallet, swapProvider, arkProvider, indexerProvider };
       expect(() => new ArkadeLightning({ ...params })).not.toThrow();
       expect(() => new ArkadeLightning({ ...params, storageProvider })).not.toThrow();
-      expect(() => new ArkadeLightning({ ...params, arkProvider: null })).toThrow('Ark provider is required either in wallet or config.');
-      expect(() => new ArkadeLightning({ ...params, swapProvider: null })).toThrow('Swap provider is required.');
-      expect(() => new ArkadeLightning({ ...params, indexerProvider: null })).toThrow('Indexer provider is required either in wallet or config.');
+      expect(() => new ArkadeLightning({ ...params, arkProvider: null as any })).toThrow('Ark provider is required either in wallet or config.');
+      expect(() => new ArkadeLightning({ ...params, swapProvider: null as any })).toThrow('Swap provider is required.');
+      expect(() => new ArkadeLightning({ ...params, indexerProvider: null as any })).toThrow('Indexer provider is required either in wallet or config.');
     });
 
     it('should have expected interface methods', () => {
@@ -268,7 +275,7 @@ describe('ArkadeLightning', () => {
         }),
         sign: vi.fn(),
         // ServiceWorkerWallet doesn't have providers
-      } as any;
+      } as ServiceWorkerWallet;
 
       // Should be able to create ArkadeLightning with external providers
       expect(() => new ArkadeLightning({ 
@@ -296,10 +303,8 @@ describe('ArkadeLightning', () => {
           sign: vi.fn().mockResolvedValue({ txid: mock.txid, hex: mock.hex }),
         }),
         sign: vi.fn(),
-        // No providers (undefined)
-        arkProvider: undefined,
-        indexerProvider: undefined,
-      } as any;
+        // ServiceWorkerWallet doesn't have provider properties
+      } as ServiceWorkerWallet;
 
       // Should throw when missing both external providers
       expect(() => new ArkadeLightning({ 
@@ -360,7 +365,21 @@ describe('ArkadeLightning', () => {
         response: createReverseSwapResponse,
         status: 'swap.created',
       };
-      vi.spyOn(arkProvider, 'getInfo').mockResolvedValueOnce({ signerPubkey: hex.encode(mock.pubkeys.server) } as any);
+      vi.spyOn(arkProvider, 'getInfo').mockResolvedValueOnce({ 
+        signerPubkey: hex.encode(mock.pubkeys.server),
+        network: 'regtest',
+        vtxoTreeExpiry: 604800n,
+        unilateralExitDelay: 604800n,
+        roundInterval: 604800n,
+        dust: 333n,
+        forfeitAddress: 'mock-forfeit-address',
+        version: '1.0.0',
+        boardingExitDelay: 604800n,
+        vtxoMaxAmount: 21000000n * 100_000_000n,
+        utxoMaxAmount: 21000000n * 100_000_000n,
+        vtxoMinAmount: -1n,
+        utxoMinAmount: -1n,
+      });
       vi.spyOn(lightning, 'createVHTLCScript').mockReturnValueOnce(mockVHTLC);
       vi.spyOn(indexerProvider, 'getVtxos').mockResolvedValueOnce({ vtxos: [] });
       vi.spyOn(arkProvider, 'submitTx').mockResolvedValueOnce({ arkTxid: '', finalArkTx: '', signedCheckpointTxs: [] });

--- a/tests/arkade-lightning.test.ts
+++ b/tests/arkade-lightning.test.ts
@@ -267,9 +267,7 @@ describe('ArkadeLightning', () => {
           sign: vi.fn().mockResolvedValue({ txid: mock.txid, hex: mock.hex }),
         }),
         sign: vi.fn(),
-        // No arkProvider or indexerProvider (undefined)
-        arkProvider: undefined,
-        indexerProvider: undefined,
+        // ServiceWorkerWallet doesn't have providers
       } as any;
 
       // Should be able to create ArkadeLightning with external providers
@@ -281,7 +279,7 @@ describe('ArkadeLightning', () => {
       })).not.toThrow();
     });
 
-    it('should work with WalletWithNestedIdentity (new interface)', () => {
+    it('should work with Wallet (with optional nested identity)', () => {
       // This is what mockWallet already is - with nested identity
       expect(() => new ArkadeLightning({ 
         wallet: mockWallet, 


### PR DESCRIPTION
I propose as temporary fix that handles both Wallet and ServiceWorkerWallet implementations, allowing us to migrate in a more graceful way in a v0.2 of the package where we can consolidate the two implementation under a common set of interfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added compatibility with both modern (nested identity) and legacy (top-level identity) wallet interfaces; app auto-detects supported wallet shape and resolves required providers at construction.

- Documentation
  - Added a "Wallet Compatibility" section with examples and setup guidance for both wallet patterns.

- Tests
  - Added tests validating construction and compatibility for both wallet interface styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->