### PR TITLE
Do not key swaps by 'type'

### DIFF
--- a/src/arkade-lightning.ts
+++ b/src/arkade-lightning.ts
@@ -106,7 +106,7 @@ export class ArkadeLightning {
         await this.wallet.contractRepository.saveToContractCollection(
             "reverseSwaps",
             swap,
-            "type"
+            "id"
         );
     }
 
@@ -116,7 +116,7 @@ export class ArkadeLightning {
         await this.wallet.contractRepository.saveToContractCollection(
             "submarineSwaps",
             swap,
-            "type"
+            "id"
         );
     }
 
@@ -215,9 +215,7 @@ export class ArkadeLightning {
         } catch (error: any) {
             if (error.isRefundable) {
                 await this.refundVHTLC(pendingSwap);
-                const finalStatus = await this.getSwapStatus(
-                    pendingSwap.response.id
-                );
+                const finalStatus = await this.getSwapStatus(pendingSwap.id);
                 await this.savePendingSubmarineSwap({
                     ...pendingSwap,
                     status: finalStatus.status,
@@ -257,6 +255,7 @@ export class ArkadeLightning {
 
         // create pending swap object
         const pendingSwap: PendingSubmarineSwap = {
+            id: swapResponse.id,
             type: "submarine",
             createdAt: Math.floor(Date.now() / 1000),
             request: swapRequest,
@@ -311,6 +310,7 @@ export class ArkadeLightning {
             await this.swapProvider.createReverseSwap(swapRequest);
 
         const pendingSwap: PendingReverseSwap = {
+            id: swapResponse.id,
             type: "reverse",
             createdAt: Math.floor(Date.now() / 1000),
             preimage: hex.encode(preimage),
@@ -460,7 +460,7 @@ export class ArkadeLightning {
         await this.arkProvider.finalizeTx(arkTxid, finalCheckpoints);
 
         // update the pending swap on storage if available
-        const finalStatus = await this.getSwapStatus(pendingSwap.response.id);
+        const finalStatus = await this.getSwapStatus(pendingSwap.id);
         await this.savePendingReverseSwap({
             ...pendingSwap,
             status: finalStatus.status,
@@ -599,7 +599,7 @@ export class ArkadeLightning {
         await this.arkProvider.finalizeTx(arkTxid, finalCheckpoints);
 
         // update the pending swap on storage if available
-        const finalStatus = await this.getSwapStatus(pendingSwap.response.id);
+        const finalStatus = await this.getSwapStatus(pendingSwap.id);
         await this.savePendingSubmarineSwap({
             ...pendingSwap,
             status: finalStatus.status,
@@ -633,14 +633,14 @@ export class ArkadeLightning {
                         });
                         const swapStatus =
                             await this.swapProvider.getReverseSwapTxId(
-                                pendingSwap.response.id
+                                pendingSwap.id
                             );
                         const txid = swapStatus.id;
 
                         if (!txid || txid.trim() === "") {
                             reject(
                                 new SwapError({
-                                    message: `Transaction ID not available for settled swap ${pendingSwap.response.id}.`,
+                                    message: `Transaction ID not available for settled swap ${pendingSwap.id}.`,
                                 })
                             );
                             break;
@@ -696,10 +696,7 @@ export class ArkadeLightning {
                 }
             };
 
-            this.swapProvider.monitorSwap(
-                pendingSwap.response.id,
-                onStatusUpdate
-            );
+            this.swapProvider.monitorSwap(pendingSwap.id, onStatusUpdate);
         });
     }
 
@@ -765,7 +762,7 @@ export class ArkadeLightning {
                         isResolved = true;
                         const { preimage } =
                             await this.swapProvider.getSwapPreimage(
-                                pendingSwap.response.id
+                                pendingSwap.id
                             );
                         await this.savePendingSubmarineSwap({
                             ...pendingSwap,
@@ -786,7 +783,7 @@ export class ArkadeLightning {
 
             // Start monitoring - the WebSocket will auto-close on terminal states
             this.swapProvider
-                .monitorSwap(pendingSwap.response.id, onStatusUpdate)
+                .monitorSwap(pendingSwap.id, onStatusUpdate)
                 .catch((error) => {
                     if (!isResolved) {
                         isResolved = true;
@@ -1008,26 +1005,26 @@ export class ArkadeLightning {
         // refresh status of all pending reverse swaps
         for (const swap of await this.getPendingReverseSwapsFromStorage()) {
             if (isReverseFinalStatus(swap.status)) continue;
-            this.getSwapStatus(swap.response.id)
+            this.getSwapStatus(swap.id)
                 .then(({ status }) => {
                     this.savePendingReverseSwap({ ...swap, status });
                 })
                 .catch((error) => {
                     console.error(
-                        `Failed to refresh swap status for ${swap.response.id}:`,
+                        `Failed to refresh swap status for ${swap.id}:`,
                         error
                     );
                 });
         }
         for (const swap of await this.getPendingSubmarineSwapsFromStorage()) {
             if (isSubmarineFinalStatus(swap.status)) continue;
-            this.getSwapStatus(swap.response.id)
+            this.getSwapStatus(swap.id)
                 .then(({ status }) => {
                     this.savePendingSubmarineSwap({ ...swap, status });
                 })
                 .catch((error) => {
                     console.error(
-                        `Failed to refresh swap status for ${swap.response.id}:`,
+                        `Failed to refresh swap status for ${swap.id}:`,
                         error
                     );
                 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface SendLightningPaymentResponse {
 }
 
 export interface PendingReverseSwap {
+    id: string;
     type: "reverse";
     createdAt: number;
     preimage: string;
@@ -61,6 +62,7 @@ export interface PendingReverseSwap {
 }
 
 export interface PendingSubmarineSwap {
+    id: string;
     type: "submarine";
     createdAt: number;
     preimage?: string;


### PR DESCRIPTION
Passing "type" as the storage key means every reverse swap overwrites the previous one (same for submarine swaps), because the key is always "reverse"/"submarine". Persist each swap under a unique identifier (e.g., swap.id) otherwise you silently lose history.

Add new id key to swaps objects (from response.id) to use with contract repository.

@tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More reliable tracking and monitoring of reverse and submarine swaps.
  - Error messages and status updates now consistently show the correct swap ID.
  - Improved swap history sorting and status refresh behavior.

- Refactor
  - Standardized use of a single swap identifier across workflows and storage for consistency.

- Chores
  - Updated and consolidated test data and mocks to enhance test coverage and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->