### PR TITLE
Remove maxFeeSats support from sendLightningPayment

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ if (limits && decodedInvoice.amountSats >= limits.min && decodedInvoice.amountSa
   // Amount is valid for swaps
   const paymentResult = await arkadeLightning.sendLightningPayment({
     invoice: invoice,
-    maxFeeSats: 1000,
   });
   console.log('Payment successful!');
 } else {
@@ -253,7 +252,6 @@ console.log('Payment Hash:', invoiceDetails.paymentHash);
 // Pay the Lightning invoice from your Arkade wallet
 const paymentResult = await arkadeLightning.sendLightningPayment({
   invoice: 'lnbc500u1pj...', // Lightning invoice string
-  maxFeeSats: 1000, // Optional: Maximum fee you're willing to pay (in sats)
 });
 
 console.log('Payment successful!');

--- a/src/arkade-lightning.ts
+++ b/src/arkade-lightning.ts
@@ -185,17 +185,6 @@ export class ArkadeLightning {
     ): Promise<SendLightningPaymentResponse> {
         const pendingSwap = await this.createSubmarineSwap(args);
 
-        // validate max fee if provided
-        if (args.maxFeeSats != null) {
-            const invoiceAmount = decodeInvoice(args.invoice).amountSats ?? 0;
-            const fees = pendingSwap.response.expectedAmount - invoiceAmount;
-            if (invoiceAmount > 0 && fees > args.maxFeeSats) {
-                throw new SwapError({
-                    message: `Swap fees ${fees} exceed max allowed ${args.maxFeeSats}`,
-                });
-            }
-        }
-
         // save pending swap to storage
         await this.savePendingSubmarineSwap(pendingSwap);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,6 @@ export interface CreateLightningInvoiceResponse {
 }
 export interface SendLightningPaymentRequest {
     invoice: string;
-    maxFeeSats?: number;
 }
 
 export interface SendLightningPaymentResponse {


### PR DESCRIPTION
After speaking with boltz we realized is not something we can really enforce well as there is routing which is hard to estimate

## Summary
- remove the max fee validation logic from `sendLightningPayment`
- drop the `maxFeeSats` field from the payment request type
- update the README examples to reflect the simplified API

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_b_68eaeff7e498832c8574d770e4b09cb2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed the option to specify a maximum fee for Lightning payments; transactions now rely on default fee handling. Fee-cap validation has been eliminated, and the request shape no longer includes a max-fee field.
- Documentation
  - Updated README examples to remove the max-fee argument and reflect the streamlined payment request. Users who previously supplied a max fee should omit it going forward; general payment behavior remains the same aside from using default fee policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->