### PR TITLE
Fix integration test

### DIFF
--- a/test/e2e/integration.test.ts
+++ b/test/e2e/integration.test.ts
@@ -18,9 +18,14 @@ it("should recover swept VHTLCs", { timeout: 120_000 }, async () => {
     expect("payment_request" in outputJSON).toBeTruthy();
     const invoice = outputJSON.payment_request;
 
+    // cancel invoice to make the swap fail
+    expect("r_hash" in outputJSON).toBeTruthy();
+    const hash = outputJSON.r_hash;
+    exec(`docker exec lnd lncli --network=regtest cancelinvoice ${hash}`);
+
     const swap = await arkadeLightning.createSubmarineSwap({ invoice });
-    // fund the vhtlc after fulmine is down so it can be swept
-    exec(`docker compose -f test.docker-compose.yml stop boltz-fulmine`);
+
+    // fund the vhtlc after is canceled so it can be swept
     exec(
         `docker exec -t arkd ark send --to ${swap.response.address} --amount ${swap.response.expectedAmount} --password secret`
     );


### PR DESCRIPTION
This PR fixes a deprecated usage of it() in tests and cancels invoice instead of stopping fulmine to make a VTHLC fail.

1. `it(name, func, options)` is deprecated, we should use `it(name, options, func)` instead

2. Stopping Fulmine to make the VHTLC fail has 2 major drawbacks:
- It must be tested using boltz-swap regtest, but as a developer I like to have a generic regtest running to test every project
- After tests Fulmine must be re-initialized

It's cleaner if we just cancel the invoice (example code)
```typescript
    const { stdout } = await promisify(exec)(
        `docker exec lnd lncli --network=regtest addinvoice --amt 1000`
    );
    const output = stdout.trim();
    expect(output).toBeDefined();
    expect(output).toBeTruthy();
    const outputJSON = JSON.parse(output);
    expect("payment_request" in outputJSON).toBeTruthy();
    const invoice = outputJSON.payment_request;

    // cancel invoice to make the swap fail
    expect("r_hash" in outputJSON).toBeTruthy();
    const hash = outputJSON.r_hash;
    exec(`docker exec lnd lncli --network=regtest cancelinvoice ${hash}`);
  ```
  
  instead of killing fulmine
  ```typescript
    const { stdout } = await promisify(exec)(
        `docker exec lnd lncli --network=regtest addinvoice --amt 1000`
    );
    const output = stdout.trim();
    expect(output).toBeDefined();
    expect(output).toBeTruthy();
    const outputJSON = JSON.parse(output);
    expect("payment_request" in outputJSON).toBeTruthy();
    const invoice = outputJSON.payment_request;
    
    // stop fulmine to make swap fail
    exec(`docker compose -f test.docker-compose.yml stop boltz-fulmine`);
```

@louisinger please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restructured integration test flow and invocation style for improved test organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->