### PR TITLE
Hex field optional in ReverseSwap tx

### DIFF
--- a/src/boltz-swap-provider.ts
+++ b/src/boltz-swap-provider.ts
@@ -141,7 +141,7 @@ export const isSubmarineSwapRefundable = (
 
 export type GetReverseSwapTxIdResponse = {
     id: string;
-    hex: string;
+    hex?: string;
     timeoutBlockHeight: number;
 };
 
@@ -152,7 +152,6 @@ export const isGetReverseSwapTxIdResponse = (
         data &&
         typeof data === "object" &&
         typeof data.id === "string" &&
-        typeof data.hex === "string" &&
         typeof data.timeoutBlockHeight === "number"
     );
 };


### PR DESCRIPTION
As discussed.

To test it:
```
$ nigiri start --ln
$ pnpm run regtest:up
$ pnpm run regtest:setup
# generate ln invoice on wallet
$ docker exec lnd lncli --network=regtest payinvoice {invoice} --force
```

On `master` you get:
```
SchemaError: error fetching txid for swap: JeChWGDYHc5G
    at BoltzSwapProvider.getReverseSwapTxId (index.js:246:13)
```

It doesn't break the flow because our wallet doesn't rely on the returned `txid` but it would break other clients if they do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of swap response validation to allow responses without certain fields, enhancing system flexibility and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->