### PR TITLE
fix: align restore schema with Boltz swagger spec

### DIFF
--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -2199,12 +2199,15 @@ export class ArkadeSwaps {
                     },
                 } as BoltzSubmarineSwap);
             } else if (isRestoredChainSwap(swap)) {
+                const refundDetails = swap.refundDetails;
+                if (!refundDetails) continue;
+
                 const {
                     amount,
                     lockupAddress,
                     serverPublicKey,
                     timeoutBlockHeight,
-                } = swap.refundDetails;
+                } = refundDetails;
 
                 chainSwaps.push({
                     id,

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -449,6 +449,11 @@ export class ArkadeSwaps {
         if (!pendingSwap.preimage)
             throw new Error("Preimage is required to claim VHTLC");
 
+        const { refundPublicKey, lockupAddress, timeoutBlockHeights } =
+            pendingSwap.response;
+        if (!refundPublicKey || !lockupAddress || !timeoutBlockHeights)
+            throw new Error("Incomplete reverse swap response");
+
         const preimage = hex.decode(pendingSwap.preimage);
         const arkInfo = await this.arkProvider.getInfo();
         const address = await this.wallet.getAddress();
@@ -460,7 +465,7 @@ export class ArkadeSwaps {
         );
 
         const senderXOnly = normalizeToXOnlyKey(
-            hex.decode(pendingSwap.response.refundPublicKey),
+            hex.decode(refundPublicKey),
             "boltz",
             pendingSwap.id
         );
@@ -478,12 +483,12 @@ export class ArkadeSwaps {
             receiverPubkey: hex.encode(receiverXOnly),
             senderPubkey: hex.encode(senderXOnly),
             serverPubkey: hex.encode(serverXOnly),
-            timeoutBlockHeights: pendingSwap.response.timeoutBlockHeights,
+            timeoutBlockHeights,
         });
 
         if (!vhtlcScript.claimScript)
             throw new Error("Failed to create VHTLC script for reverse swap");
-        if (vhtlcAddress !== pendingSwap.response.lockupAddress)
+        if (vhtlcAddress !== lockupAddress)
             throw new Error("Boltz is trying to scam us");
 
         // get spendable VTXOs from the lockup address
@@ -662,6 +667,8 @@ export class ArkadeSwaps {
         args: SendLightningPaymentRequest
     ): Promise<SendLightningPaymentResponse> {
         const pendingSwap = await this.createSubmarineSwap(args);
+        if (!pendingSwap.response.address)
+            throw new Error("Missing address in submarine swap response");
 
         // save pending swap to storage
         await this.savePendingSubmarineSwap(pendingSwap);
@@ -773,8 +780,12 @@ export class ArkadeSwaps {
             pendingSwap.id
         );
 
+        const { claimPublicKey, timeoutBlockHeights } = pendingSwap.response;
+        if (!claimPublicKey || !timeoutBlockHeights)
+            throw new Error("Incomplete submarine swap response");
+
         const boltzXOnlyPublicKey = normalizeToXOnlyKey(
-            hex.decode(pendingSwap.response.claimPublicKey),
+            hex.decode(claimPublicKey),
             "boltz",
             pendingSwap.id
         );
@@ -785,7 +796,7 @@ export class ArkadeSwaps {
             receiverPubkey: hex.encode(boltzXOnlyPublicKey),
             senderPubkey: hex.encode(ourXOnlyPublicKey),
             serverPubkey: hex.encode(serverXOnlyPublicKey),
-            timeoutBlockHeights: pendingSwap.response.timeoutBlockHeights,
+            timeoutBlockHeights,
         });
 
         if (!vhtlcScript.claimScript)
@@ -2108,6 +2119,7 @@ export class ArkadeSwaps {
                     preimageHash,
                     serverPublicKey,
                     tree,
+                    timeoutBlockHeights,
                 } = swap.claimDetails;
 
                 reverseSwaps.push({
@@ -2124,19 +2136,20 @@ export class ArkadeSwaps {
                         onchainAmount: amount,
                         lockupAddress,
                         refundPublicKey: serverPublicKey,
-                        timeoutBlockHeights: {
+                        timeoutBlockHeights: timeoutBlockHeights ?? {
                             refund: extractTimeLockFromLeafOutput(
-                                tree.refundWithoutBoltzLeaf.output
+                                tree.refundWithoutBoltzLeaf?.output ?? ""
                             ),
                             unilateralClaim: extractTimeLockFromLeafOutput(
-                                tree.unilateralClaimLeaf.output
+                                tree.unilateralClaimLeaf?.output ?? ""
                             ),
                             unilateralRefund: extractTimeLockFromLeafOutput(
-                                tree.unilateralRefundLeaf.output
+                                tree.unilateralRefundLeaf?.output ?? ""
                             ),
                             unilateralRefundWithoutReceiver:
                                 extractTimeLockFromLeafOutput(
-                                    tree.unilateralRefundWithoutBoltzLeaf.output
+                                    tree.unilateralRefundWithoutBoltzLeaf
+                                        ?.output ?? ""
                                 ),
                         },
                     },
@@ -2145,8 +2158,13 @@ export class ArkadeSwaps {
                     preimage: "",
                 } as BoltzReverseSwap);
             } else if (isRestoredSubmarineSwap(swap)) {
-                const { amount, lockupAddress, serverPublicKey, tree } =
-                    swap.refundDetails;
+                const {
+                    amount,
+                    lockupAddress,
+                    serverPublicKey,
+                    tree,
+                    timeoutBlockHeights,
+                } = swap.refundDetails;
 
                 let preimage = "";
                 // Skip preimage fetch for terminal swaps — nothing actionable
@@ -2181,19 +2199,20 @@ export class ArkadeSwaps {
                         address: lockupAddress,
                         expectedAmount: amount,
                         claimPublicKey: serverPublicKey,
-                        timeoutBlockHeights: {
+                        timeoutBlockHeights: timeoutBlockHeights ?? {
                             refund: extractTimeLockFromLeafOutput(
-                                tree.refundWithoutBoltzLeaf.output
+                                tree.refundWithoutBoltzLeaf?.output ?? ""
                             ),
                             unilateralClaim: extractTimeLockFromLeafOutput(
-                                tree.unilateralClaimLeaf.output
+                                tree.unilateralClaimLeaf?.output ?? ""
                             ),
                             unilateralRefund: extractTimeLockFromLeafOutput(
-                                tree.unilateralRefundLeaf.output
+                                tree.unilateralRefundLeaf?.output ?? ""
                             ),
                             unilateralRefundWithoutReceiver:
                                 extractTimeLockFromLeafOutput(
-                                    tree.unilateralRefundWithoutBoltzLeaf.output
+                                    tree.unilateralRefundWithoutBoltzLeaf
+                                        ?.output ?? ""
                                 ),
                         },
                     },

--- a/src/boltz-swap-provider.ts
+++ b/src/boltz-swap-provider.ts
@@ -827,7 +827,7 @@ export type Details = {
     };
     lockupAddress: string;
     serverPublicKey: string;
-    timeoutBlockHeight: number;
+    timeoutBlockHeight?: number;
     timeoutBlockHeights?: TimeoutBlockHeights;
     preimageHash?: string;
 };
@@ -846,7 +846,8 @@ export const isDetails = (data: any): data is Details => {
                 typeof data.transaction.vout === "number")) &&
         typeof data.lockupAddress === "string" &&
         typeof data.serverPublicKey === "string" &&
-        typeof data.timeoutBlockHeight === "number" &&
+        (data.timeoutBlockHeight === undefined ||
+            typeof data.timeoutBlockHeight === "number") &&
         (data.timeoutBlockHeights === undefined ||
             isTimeoutBlockHeights(data.timeoutBlockHeights)) &&
         (data.preimageHash === undefined ||
@@ -861,19 +862,10 @@ export type RestoredChainSwap = {
     createdAt: number;
     from: "ARK" | "BTC";
     to: "ARK" | "BTC";
-    preimageHash: string;
-    refundDetails: {
-        amount: number;
-        keyIndex: number;
-        lockupAddress: string;
-        serverPublicKey: string;
-        timeoutBlockHeight: number;
-        transaction?: {
-            id: string;
-            vout: number;
-        };
-        tree: Tree;
-    };
+    preimageHash?: string;
+    invoice?: string;
+    refundDetails?: Details;
+    claimDetails?: Details;
 };
 
 export const isRestoredChainSwap = (data: any): data is RestoredChainSwap => {
@@ -886,20 +878,11 @@ export const isRestoredChainSwap = (data: any): data is RestoredChainSwap => {
         typeof data.createdAt === "number" &&
         (data.from === "ARK" || data.from === "BTC") &&
         (data.to === "ARK" || data.to === "BTC") &&
-        typeof data.preimageHash === "string" &&
-        data.refundDetails &&
-        typeof data.refundDetails === "object" &&
-        isTree(data.refundDetails.tree) &&
-        typeof data.refundDetails.amount === "number" &&
-        typeof data.refundDetails.keyIndex === "number" &&
-        (data.refundDetails.transaction === undefined ||
-            (data.refundDetails.transaction &&
-                typeof data.refundDetails.transaction === "object" &&
-                typeof data.refundDetails.transaction.id === "string" &&
-                typeof data.refundDetails.transaction.vout === "number")) &&
-        typeof data.refundDetails.lockupAddress === "string" &&
-        typeof data.refundDetails.serverPublicKey === "string" &&
-        typeof data.refundDetails.timeoutBlockHeight === "number"
+        (data.preimageHash === undefined ||
+            typeof data.preimageHash === "string") &&
+        (data.invoice === undefined || typeof data.invoice === "string") &&
+        (data.refundDetails === undefined || isDetails(data.refundDetails)) &&
+        (data.claimDetails === undefined || isDetails(data.claimDetails))
     );
 };
 
@@ -909,7 +892,7 @@ export type RestoredSubmarineSwap = {
     from: "ARK";
     type: "submarine";
     createdAt: number;
-    preimageHash: string;
+    preimageHash?: string;
     status: BoltzSwapStatus;
     refundDetails: Details;
     invoice?: string;
@@ -926,7 +909,8 @@ export const isRestoredSubmarineSwap = (
         data.from === "ARK" &&
         data.type === "submarine" &&
         typeof data.createdAt === "number" &&
-        typeof data.preimageHash === "string" &&
+        (data.preimageHash === undefined ||
+            typeof data.preimageHash === "string") &&
         typeof data.status === "string" &&
         isDetails(data.refundDetails) &&
         (data.invoice === undefined || typeof data.invoice === "string")
@@ -939,7 +923,7 @@ export type RestoredReverseSwap = {
     from: "BTC";
     type: "reverse";
     createdAt: number;
-    preimageHash: string;
+    preimageHash?: string;
     status: BoltzSwapStatus;
     claimDetails: Details;
     invoice?: string;
@@ -956,7 +940,8 @@ export const isRestoredReverseSwap = (
         data.from === "BTC" &&
         data.type === "reverse" &&
         typeof data.createdAt === "number" &&
-        typeof data.preimageHash === "string" &&
+        (data.preimageHash === undefined ||
+            typeof data.preimageHash === "string") &&
         typeof data.status === "string" &&
         isDetails(data.claimDetails) &&
         (data.invoice === undefined || typeof data.invoice === "string")

--- a/src/boltz-swap-provider.ts
+++ b/src/boltz-swap-provider.ts
@@ -284,6 +284,7 @@ export type GetSwapStatusResponse = {
     transaction?: {
         id: string;
         hex?: string;
+        confirmed?: boolean;
         eta?: number;
         preimage?: string;
     };
@@ -302,6 +303,8 @@ export const isGetSwapStatusResponse = (
             (data.transaction &&
                 typeof data.transaction === "object" &&
                 typeof data.transaction.id === "string" &&
+                (data.transaction.confirmed === undefined ||
+                    typeof data.transaction.confirmed === "boolean") &&
                 (data.transaction.eta === undefined ||
                     typeof data.transaction.eta === "number") &&
                 (data.transaction.hex === undefined ||
@@ -411,16 +414,18 @@ export type CreateSubmarineSwapRequest = {
 export type CreateSubmarineSwapResponse = {
     /** Unique swap ID. */
     id: string;
-    /** ARK lockup address to send funds to. */
-    address: string;
     /** Amount in satoshis to send. */
     expectedAmount: number;
+    /** ARK lockup address to send funds to. */
+    address?: string;
     /** Boltz's public key for the claim path. */
-    claimPublicKey: string;
+    claimPublicKey?: string;
     /** Whether zero-conf transactions are accepted. */
-    acceptZeroConf: boolean;
+    acceptZeroConf?: boolean;
+    /** Block height for the onchain HTLC timeout. */
+    timeoutBlockHeight?: number;
     /** Block heights for various timeout/refund scenarios. */
-    timeoutBlockHeights: TimeoutBlockHeights;
+    timeoutBlockHeights?: TimeoutBlockHeights;
 };
 
 export const isCreateSubmarineSwapResponse = (
@@ -430,11 +435,16 @@ export const isCreateSubmarineSwapResponse = (
         data &&
         typeof data === "object" &&
         typeof data.id === "string" &&
-        typeof data.address === "string" &&
         typeof data.expectedAmount === "number" &&
-        typeof data.claimPublicKey === "string" &&
-        typeof data.acceptZeroConf === "boolean" &&
-        isTimeoutBlockHeights(data.timeoutBlockHeights)
+        (data.address === undefined || typeof data.address === "string") &&
+        (data.claimPublicKey === undefined ||
+            typeof data.claimPublicKey === "string") &&
+        (data.acceptZeroConf === undefined ||
+            typeof data.acceptZeroConf === "boolean") &&
+        (data.timeoutBlockHeight === undefined ||
+            typeof data.timeoutBlockHeight === "number") &&
+        (data.timeoutBlockHeights === undefined ||
+            isTimeoutBlockHeights(data.timeoutBlockHeights))
     );
 };
 
@@ -469,13 +479,15 @@ export type CreateReverseSwapResponse = {
     /** BOLT11-encoded Lightning invoice to be paid. */
     invoice: string;
     /** On-chain amount in satoshis (after Boltz fees). */
-    onchainAmount: number;
+    onchainAmount?: number;
     /** ARK lockup address where Boltz will lock funds. */
-    lockupAddress: string;
+    lockupAddress?: string;
     /** Boltz's public key for the refund path. */
-    refundPublicKey: string;
+    refundPublicKey?: string;
+    /** Block height for the onchain HTLC timeout. */
+    timeoutBlockHeight?: number;
     /** Block heights for various timeout/refund scenarios. */
-    timeoutBlockHeights: TimeoutBlockHeights;
+    timeoutBlockHeights?: TimeoutBlockHeights;
 };
 
 export const isCreateReverseSwapResponse = (
@@ -486,10 +498,16 @@ export const isCreateReverseSwapResponse = (
         typeof data === "object" &&
         typeof data.id === "string" &&
         typeof data.invoice === "string" &&
-        typeof data.onchainAmount === "number" &&
-        typeof data.lockupAddress === "string" &&
-        typeof data.refundPublicKey === "string" &&
-        isTimeoutBlockHeights(data.timeoutBlockHeights)
+        (data.onchainAmount === undefined ||
+            typeof data.onchainAmount === "number") &&
+        (data.lockupAddress === undefined ||
+            typeof data.lockupAddress === "string") &&
+        (data.refundPublicKey === undefined ||
+            typeof data.refundPublicKey === "string") &&
+        (data.timeoutBlockHeight === undefined ||
+            typeof data.timeoutBlockHeight === "number") &&
+        (data.timeoutBlockHeights === undefined ||
+            isTimeoutBlockHeights(data.timeoutBlockHeights))
     );
 };
 
@@ -798,10 +816,11 @@ const isLeaf = (data: any): data is Leaf => {
 export type Tree = {
     claimLeaf: Leaf;
     refundLeaf: Leaf;
-    refundWithoutBoltzLeaf: Leaf;
-    unilateralClaimLeaf: Leaf;
-    unilateralRefundLeaf: Leaf;
-    unilateralRefundWithoutBoltzLeaf: Leaf;
+    covenantClaimLeaf?: Leaf;
+    refundWithoutBoltzLeaf?: Leaf;
+    unilateralClaimLeaf?: Leaf;
+    unilateralRefundLeaf?: Leaf;
+    unilateralRefundWithoutBoltzLeaf?: Leaf;
 };
 
 export const isTree = (data: any): data is Tree => {
@@ -810,10 +829,16 @@ export const isTree = (data: any): data is Tree => {
         typeof data === "object" &&
         isLeaf(data.claimLeaf) &&
         isLeaf(data.refundLeaf) &&
-        isLeaf(data.refundWithoutBoltzLeaf) &&
-        isLeaf(data.unilateralClaimLeaf) &&
-        isLeaf(data.unilateralRefundLeaf) &&
-        isLeaf(data.unilateralRefundWithoutBoltzLeaf)
+        (data.covenantClaimLeaf === undefined ||
+            isLeaf(data.covenantClaimLeaf)) &&
+        (data.refundWithoutBoltzLeaf === undefined ||
+            isLeaf(data.refundWithoutBoltzLeaf)) &&
+        (data.unilateralClaimLeaf === undefined ||
+            isLeaf(data.unilateralClaimLeaf)) &&
+        (data.unilateralRefundLeaf === undefined ||
+            isLeaf(data.unilateralRefundLeaf)) &&
+        (data.unilateralRefundWithoutBoltzLeaf === undefined ||
+            isLeaf(data.unilateralRefundWithoutBoltzLeaf))
     );
 };
 


### PR DESCRIPTION
## Summary

- Align `Restored*` types and runtime validators with the [Boltz POST /swap/restore](https://api.boltz.exchange/swagger#/Swap/post_swap_restore) API spec
- Fields that are optional in the API (`amount`, `timeoutBlockHeight`, `preimageHash`, `invoice`, `claimDetails`, `refundDetails`) are now correctly optional in our types and validators
- `RestoredChainSwap.refundDetails` reuses the shared `Details` type instead of a divergent inline definition; adds the missing `claimDetails` and `invoice` fields
- Chain swap restore consumer guards against missing `refundDetails`

## Test plan

- [x] `pnpm test:unit` — all 249 tests pass
- [x] `tsc --noEmit` — no new type errors
- [x] Verified `../wallet` does not import `Restored*` types — no downstream breakage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes during swap recovery when processing transaction refund details.

* **Refactor**
  * Improved swap data validation to handle missing or optional fields more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->