### PR TITLE
Fix/submarine refund fallback

### DIFF
--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -448,12 +448,16 @@ export class ArkadeSwaps {
     async claimVHTLC(pendingSwap: BoltzReverseSwap): Promise<void> {
         // restored swaps may not have preimage
         if (!pendingSwap.preimage)
-            throw new Error("Preimage is required to claim VHTLC");
+            throw new Error(
+                `Swap ${pendingSwap.id}: preimage is required to claim VHTLC`
+            );
 
         const { refundPublicKey, lockupAddress, timeoutBlockHeights } =
             pendingSwap.response;
         if (!refundPublicKey || !lockupAddress || !timeoutBlockHeights)
-            throw new Error("Incomplete reverse swap response");
+            throw new Error(
+                `Swap ${pendingSwap.id}: incomplete reverse swap response`
+            );
 
         const preimage = hex.decode(pendingSwap.preimage);
         const arkInfo = await this.arkProvider.getInfo();
@@ -488,21 +492,27 @@ export class ArkadeSwaps {
         });
 
         if (!vhtlcScript.claimScript)
-            throw new Error("Failed to create VHTLC script for reverse swap");
+            throw new Error(
+                `Swap ${pendingSwap.id}: failed to create VHTLC script for reverse swap`
+            );
         if (vhtlcAddress !== lockupAddress)
-            throw new Error("Boltz is trying to scam us");
+            throw new Error(
+                `Swap ${pendingSwap.id}: VHTLC address mismatch. Expected ${lockupAddress}, got ${vhtlcAddress}`
+            );
 
         // get spendable VTXOs from the lockup address
         const { vtxos } = await this.indexerProvider.getVtxos({
             scripts: [hex.encode(vhtlcScript.pkScript)],
         });
         if (vtxos.length === 0)
-            throw new Error("No spendable virtual coins found");
+            throw new Error(
+                `Swap ${pendingSwap.id}: no spendable virtual coins found`
+            );
 
         const vtxo = vtxos[0];
 
         if (vtxo.isSpent) {
-            throw new Error("VHTLC is already spent");
+            throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 
         const input = {
@@ -669,7 +679,9 @@ export class ArkadeSwaps {
     ): Promise<SendLightningPaymentResponse> {
         const pendingSwap = await this.createSubmarineSwap(args);
         if (!pendingSwap.response.address)
-            throw new Error("Missing address in submarine swap response");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing address in submarine swap response`
+            );
 
         // save pending swap to storage
         await this.savePendingSubmarineSwap(pendingSwap);
@@ -761,17 +773,16 @@ export class ArkadeSwaps {
             ? getInvoicePaymentHash(pendingSwap.request.invoice)
             : pendingSwap.preimageHash;
 
-        console.log(`--- 1 Refunding VHTLC for swap ${pendingSwap.id}`);
-
         if (!preimageHash)
-            throw new Error("Preimage hash is required to refund VHTLC");
+            throw new Error(
+                `Swap ${pendingSwap.id}: preimage hash is required to refund VHTLC`
+            );
 
         // prepare keys and script (independent of VTXO selection)
         const arkInfo = await this.arkProvider.getInfo();
         const address = await this.wallet.getAddress();
         if (!address) throw new Error("Failed to get ark address from wallet");
 
-        console.log(`--- 2 Refunding VHTLC for swap ${pendingSwap.id}`);
         const ourXOnlyPublicKey = normalizeToXOnlyKey(
             await this.wallet.identity.xOnlyPublicKey(),
             "our",
@@ -786,7 +797,9 @@ export class ArkadeSwaps {
 
         const { claimPublicKey, timeoutBlockHeights } = pendingSwap.response;
         if (!claimPublicKey || !timeoutBlockHeights)
-            throw new Error("Incomplete submarine swap response");
+            throw new Error(
+                `Swap ${pendingSwap.id}: incomplete submarine swap response`
+            );
 
         const boltzXOnlyPublicKey = normalizeToXOnlyKey(
             hex.decode(claimPublicKey),
@@ -804,7 +817,9 @@ export class ArkadeSwaps {
         });
 
         if (!vhtlcScript.claimScript)
-            throw new Error("Failed to create VHTLC script for submarine swap");
+            throw new Error(
+                `Swap ${pendingSwap.id}: failed to create VHTLC script for submarine swap`
+            );
 
         // sanity check: reconstructed address must match the swap response
         if (vhtlcAddress !== pendingSwap.response.address)
@@ -831,8 +846,8 @@ export class ArkadeSwaps {
             });
             throw new Error(
                 allVtxos.length > 0
-                    ? "VHTLC is already spent"
-                    : `VHTLC not found for address ${pendingSwap.response.address}`
+                    ? `Swap ${pendingSwap.id}: VHTLC is already spent`
+                    : `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.address}`
             );
         }
 
@@ -1197,17 +1212,25 @@ export class ArkadeSwaps {
      */
     async claimBtc(pendingSwap: BoltzChainSwap): Promise<void> {
         if (!pendingSwap.toAddress)
-            throw new Error("Destination address is required");
+            throw new Error(
+                `Swap ${pendingSwap.id}: destination address is required`
+            );
 
         if (!pendingSwap.response.claimDetails.swapTree)
-            throw new Error("Missing swap tree in claim details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing swap tree in claim details`
+            );
 
         if (!pendingSwap.response.claimDetails.serverPublicKey)
-            throw new Error("Missing server public key in claim details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing server public key in claim details`
+            );
 
         const swapStatus = await this.getSwapStatus(pendingSwap.id);
         if (!swapStatus.transaction?.hex)
-            throw new Error("BTC transaction hex is required");
+            throw new Error(
+                `Swap ${pendingSwap.id}: BTC transaction hex is required`
+            );
 
         const lockupTx = Transaction.fromRaw(
             hex.decode(swapStatus.transaction.hex)
@@ -1280,7 +1303,9 @@ export class ArkadeSwaps {
         );
 
         if (!signedTxData.pubNonce || !signedTxData.partialSignature)
-            throw new Error("Invalid signature data from server");
+            throw new Error(
+                `Swap ${pendingSwap.id}: invalid signature data from server`
+            );
 
         const musigSession = musigMessage
             .aggregateNonces([
@@ -1312,10 +1337,14 @@ export class ArkadeSwaps {
      */
     async refundArk(pendingSwap: BoltzChainSwap): Promise<void> {
         if (!pendingSwap.response.lockupDetails.serverPublicKey)
-            throw new Error("Missing server public key in lockup details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing server public key in lockup details`
+            );
 
         if (!pendingSwap.response.lockupDetails.timeouts)
-            throw new Error("Missing timeouts in lockup details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing timeouts in lockup details`
+            );
 
         const arkInfo = await this.arkProvider.getInfo();
 
@@ -1350,14 +1379,14 @@ export class ArkadeSwaps {
 
         if (vtxos.length === 0) {
             throw new Error(
-                `VHTLC not found for address ${pendingSwap.response.lockupDetails.lockupAddress}`
+                `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.lockupDetails.lockupAddress}`
             );
         }
 
         const vtxo = vtxos[0];
 
         if (vtxo.isSpent) {
-            throw new Error("VHTLC is already spent");
+            throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 
         const { vhtlcAddress, vhtlcScript } = this.createVHTLCScript({
@@ -1370,7 +1399,9 @@ export class ArkadeSwaps {
         });
 
         if (!vhtlcScript.refundScript)
-            throw new Error("Failed to create VHTLC script for chain swap");
+            throw new Error(
+                `Swap ${pendingSwap.id}: failed to create VHTLC script for chain swap`
+            );
 
         if (pendingSwap.response.lockupDetails.lockupAddress !== vhtlcAddress) {
             throw new SwapError({
@@ -1577,13 +1608,19 @@ export class ArkadeSwaps {
      */
     async claimArk(pendingSwap: BoltzChainSwap): Promise<void> {
         if (!pendingSwap.toAddress)
-            throw new Error("Destination address is required");
+            throw new Error(
+                `Swap ${pendingSwap.id}: destination address is required`
+            );
 
         if (!pendingSwap.response.claimDetails.serverPublicKey)
-            throw new Error("Missing server public key in claim details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing server public key in claim details`
+            );
 
         if (!pendingSwap.response.claimDetails.timeouts)
-            throw new Error("Missing timeouts in claim details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing timeouts in claim details`
+            );
 
         const arkInfo = await this.arkProvider.getInfo();
         const preimage = hex.decode(pendingSwap.preimage);
@@ -1615,7 +1652,9 @@ export class ArkadeSwaps {
         });
 
         if (!vhtlcScript.claimScript)
-            throw new Error("Failed to create VHTLC script for chain swap");
+            throw new Error(
+                `Swap ${pendingSwap.id}: failed to create VHTLC script for chain swap`
+            );
 
         if (pendingSwap.response.claimDetails.lockupAddress !== vhtlcAddress) {
             throw new SwapError({
@@ -1630,7 +1669,9 @@ export class ArkadeSwaps {
         });
 
         if (spendableVtxos.vtxos.length === 0)
-            throw new Error("No spendable virtual coins found");
+            throw new Error(
+                `Swap ${pendingSwap.id}: no spendable virtual coins found`
+            );
 
         const vtxo = spendableVtxos.vtxos[0];
 
@@ -1681,10 +1722,14 @@ export class ArkadeSwaps {
         pendingSwap: BoltzChainSwap
     ): Promise<void> {
         if (!pendingSwap.response.lockupDetails.swapTree)
-            throw new Error("Missing swap tree in lockup details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing swap tree in lockup details`
+            );
 
         if (!pendingSwap.response.lockupDetails.serverPublicKey)
-            throw new Error("Missing server public key in lockup details");
+            throw new Error(
+                `Swap ${pendingSwap.id}: missing server public key in lockup details`
+            );
 
         const claimDetails = await this.swapProvider.getChainClaimDetails(
             pendingSwap.id
@@ -1696,7 +1741,7 @@ export class ArkadeSwaps {
         const serverPubKey = pendingSwap.response.lockupDetails.serverPublicKey;
         if (claimDetails.publicKey !== serverPubKey) {
             throw new Error(
-                `Server public key mismatch: claim response has ${claimDetails.publicKey}, expected ${serverPubKey}`
+                `Swap ${pendingSwap.id}: server public key mismatch — claim response has ${claimDetails.publicKey}, expected ${serverPubKey}`
             );
         }
 
@@ -1873,16 +1918,24 @@ export class ArkadeSwaps {
 
         if (from === "ARK") {
             if (!swap.response.lockupDetails.serverPublicKey)
-                throw new Error("Missing serverPublicKey in lockup details");
+                throw new Error(
+                    `Swap ${swap.id}: missing serverPublicKey in lockup details`
+                );
             if (!swap.response.lockupDetails.timeouts)
-                throw new Error("Missing timeouts in lockup details");
+                throw new Error(
+                    `Swap ${swap.id}: missing timeouts in lockup details`
+                );
         }
 
         if (to === "ARK") {
             if (!swap.response.claimDetails.serverPublicKey)
-                throw new Error("Missing serverPublicKey in claim details");
+                throw new Error(
+                    `Swap ${swap.id}: missing serverPublicKey in claim details`
+                );
             if (!swap.response.claimDetails.timeouts)
-                throw new Error("Missing timeouts in claim details");
+                throw new Error(
+                    `Swap ${swap.id}: missing timeouts in claim details`
+                );
         }
 
         const lockupAddress =

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -6,6 +6,7 @@ import {
     TransactionFailedError,
     TransactionLockupFailedError,
     TransactionRefundedError,
+    BoltzRefundError,
 } from "./errors";
 import {
     ArkAddress,
@@ -760,6 +761,8 @@ export class ArkadeSwaps {
             ? getInvoicePaymentHash(pendingSwap.request.invoice)
             : pendingSwap.preimageHash;
 
+        console.log(`--- 1 Refunding VHTLC for swap ${pendingSwap.id}`);
+
         if (!preimageHash)
             throw new Error("Preimage hash is required to refund VHTLC");
 
@@ -768,6 +771,7 @@ export class ArkadeSwaps {
         const address = await this.wallet.getAddress();
         if (!address) throw new Error("Failed to get ark address from wallet");
 
+        console.log(`--- 2 Refunding VHTLC for swap ${pendingSwap.id}`);
         const ourXOnlyPublicKey = normalizeToXOnlyKey(
             await this.wallet.identity.xOnlyPublicKey(),
             "our",
@@ -833,6 +837,10 @@ export class ArkadeSwaps {
         }
 
         const outputScript = ArkAddress.decode(address).pkScript;
+        const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
+        const refundLocktime = BigInt(timeoutBlockHeights.refund);
+        const currentBlockHeight = await this.swapProvider.getChainHeight();
+        const cltvSatisfied = BigInt(currentBlockHeight) >= refundLocktime;
 
         // Refund every unspent VTXO at the contract address.
         // Throttle between Boltz API calls to avoid 429 rate-limiting.
@@ -841,27 +849,48 @@ export class ArkadeSwaps {
         for (const vtxo of spendableVtxos) {
             const isRecoverableVtxo = isRecoverable(vtxo);
 
-            const input = {
-                ...vtxo,
-                tapLeafScript: isRecoverableVtxo
-                    ? vhtlcScript.refundWithoutReceiver()
-                    : vhtlcScript.refund(),
-                tapTree: vhtlcScript.encode(),
-            };
-
             const output = {
                 amount: BigInt(vtxo.value),
                 script: outputScript,
             };
 
-            if (isRecoverableVtxo) {
+            // Prefer refundWithoutReceiver (sender + server, no Boltz) when
+            // the CLTV locktime has passed — works for both recoverable and
+            // non-recoverable VTXOs.
+            if (cltvSatisfied) {
+                const input = {
+                    ...vtxo,
+                    tapLeafScript: refundWithoutReceiverLeaf,
+                    tapTree: vhtlcScript.encode(),
+                };
                 await this.joinBatch(
                     this.wallet.identity,
                     input,
                     output,
-                    arkInfo
+                    arkInfo,
+                    isRecoverableVtxo
                 );
-            } else {
+                continue;
+            }
+
+            // Pre-CLTV: recoverable VTXOs can't use the Boltz 3-of-3 path
+            // (Boltz can't co-sign a swept-batch refund), so we must wait.
+            if (isRecoverableVtxo) {
+                throw new Error(
+                    `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
+                        `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
+                        `(refundLocktime=${timeoutBlockHeights.refund}, ` +
+                        `currentBlockHeight=${currentBlockHeight}). Refund will be retried after locktime.`
+                );
+            }
+
+            // Pre-CLTV, non-recoverable: try the 3-of-3 refund via Boltz.
+            const input = {
+                ...vtxo,
+                tapLeafScript: vhtlcScript.refund(),
+                tapTree: vhtlcScript.encode(),
+            };
+            try {
                 if (boltzCallCount > 0) {
                     await new Promise((r) => setTimeout(r, 2000));
                 }
@@ -880,6 +909,42 @@ export class ArkadeSwaps {
                     )
                 );
                 boltzCallCount++;
+            } catch (error) {
+                // Only fall back for Boltz-side rejections (e.g. outpoint
+                // mismatch after an Ark round). Re-throw anything else.
+                if (!(error instanceof BoltzRefundError)) {
+                    throw error;
+                }
+
+                // Re-check chain tip — it may have advanced while talking
+                // to Boltz.
+                const tipNow = await this.swapProvider.getChainHeight();
+                if (BigInt(tipNow) < refundLocktime) {
+                    throw new Error(
+                        `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
+                            `refundWithoutReceiver locktime has not passed yet ` +
+                            `(currentBlockHeight=${tipNow}, ` +
+                            `locktime=${timeoutBlockHeights.refund}). ` +
+                            `Refund will be retried after locktime.`
+                    );
+                }
+
+                logger.warn(
+                    `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
+                        `falling back to refundWithoutReceiver via joinBatch`
+                );
+                const fallbackInput = {
+                    ...vtxo,
+                    tapLeafScript: refundWithoutReceiverLeaf,
+                    tapTree: vhtlcScript.encode(),
+                };
+                await this.joinBatch(
+                    this.wallet.identity,
+                    fallbackInput,
+                    output,
+                    arkInfo,
+                    false
+                );
             }
         }
 

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -860,6 +860,7 @@ export class ArkadeSwaps {
         // Refund every unspent VTXO at the contract address.
         // Throttle between Boltz API calls to avoid 429 rate-limiting.
         let boltzCallCount = 0;
+        let skippedCount = 0;
 
         for (const vtxo of spendableVtxos) {
             const isRecoverableVtxo = isRecoverable(vtxo);
@@ -897,6 +898,7 @@ export class ArkadeSwaps {
                         `(refundLocktime=${timeoutBlockHeights.refund}, ` +
                         `currentBlockHeight=${currentBlockHeight}). Refund will be retried after locktime.`
                 );
+                skippedCount++;
                 continue;
             }
 
@@ -943,6 +945,7 @@ export class ArkadeSwaps {
                             `locktime=${timeoutBlockHeights.refund}). ` +
                             `Refund will be retried after locktime.`
                     );
+                    skippedCount++;
                     continue;
                 }
 
@@ -966,11 +969,12 @@ export class ArkadeSwaps {
         }
 
         // update the pending swap on storage
+        const fullyRefunded = skippedCount === 0;
         await updateSubmarineSwapStatus(
             pendingSwap,
             pendingSwap.status, // Keep current status
             this.savePendingSubmarineSwap.bind(this),
-            { refundable: true, refunded: true }
+            { refundable: true, refunded: fullyRefunded }
         );
     }
 

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -891,12 +891,13 @@ export class ArkadeSwaps {
             // Pre-CLTV: recoverable VTXOs can't use the Boltz 3-of-3 path
             // (Boltz can't co-sign a swept-batch refund), so we must wait.
             if (isRecoverableVtxo) {
-                throw new Error(
+                logger.error(
                     `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
                         `(refundLocktime=${timeoutBlockHeights.refund}, ` +
                         `currentBlockHeight=${currentBlockHeight}). Refund will be retried after locktime.`
                 );
+                continue;
             }
 
             // Pre-CLTV, non-recoverable: try the 3-of-3 refund via Boltz.
@@ -935,13 +936,14 @@ export class ArkadeSwaps {
                 // to Boltz.
                 const tipNow = await this.swapProvider.getChainHeight();
                 if (BigInt(tipNow) < refundLocktime) {
-                    throw new Error(
+                    logger.error(
                         `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
                             `(currentBlockHeight=${tipNow}, ` +
                             `locktime=${timeoutBlockHeights.refund}). ` +
                             `Refund will be retried after locktime.`
                     );
+                    continue;
                 }
 
                 logger.warn(

--- a/src/boltz-swap-provider.ts
+++ b/src/boltz-swap-provider.ts
@@ -1085,6 +1085,19 @@ export class BoltzSwapProvider {
         };
     }
 
+    /** Returns the current BTC chain tip height from Boltz. */
+    async getChainHeight(): Promise<number> {
+        const response = await this.request<{ BTC: number }>(
+            "/v2/chain/heights",
+            "GET"
+        );
+        if (typeof response?.BTC !== "number")
+            throw new SchemaError({
+                message: "error fetching chain heights",
+            });
+        return response.BTC;
+    }
+
     /** Gets the lockup transaction ID for a reverse swap. */
     async getReverseSwapTxId(id: string): Promise<GetReverseSwapTxIdResponse> {
         const res = await this.request<GetReverseSwapTxIdResponse>(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -132,11 +132,16 @@ export class TransactionRefundedError extends SwapError {
     }
 }
 
-/** Returns true if the error is a Boltz 400 "transaction is not for this swap". */
-export function isVtxoMismatchError(error: unknown): boolean {
-    return (
-        error instanceof NetworkError &&
-        error.statusCode === 400 &&
-        error.errorData?.error === "transaction is not for this swap"
-    );
+/**
+ * Thrown when the Boltz API rejects a refund request
+ * (e.g. outpoint mismatch after an Ark round).
+ */
+export class BoltzRefundError extends Error {
+    constructor(
+        message: string,
+        public override readonly cause?: unknown
+    ) {
+        super(message);
+        this.name = "BoltzRefundError";
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export {
     NetworkError,
     PreimageFetchError,
     TransactionFailedError,
+    BoltzRefundError,
 } from "./errors";
 export {
     decodeInvoice,

--- a/src/utils/vhtlc.ts
+++ b/src/utils/vhtlc.ts
@@ -17,6 +17,7 @@ import {
     TapLeafScript,
 } from "@arkade-os/sdk";
 import { logger } from "../logger";
+import { BoltzRefundError } from "../errors";
 import { hex, base64 } from "@scure/base";
 import { createVHTLCBatchHandler } from "../batch";
 import { ripemd160 } from "@noble/hashes/legacy.js";
@@ -348,10 +349,22 @@ export const refundVHTLCwithOffchainTx = async (
     const unsignedCheckpointTx = checkpointPtxs[0];
 
     // get Boltz to sign its part
-    const {
-        transaction: boltzSignedRefundTx,
-        checkpoint: boltzSignedCheckpointTx,
-    } = await refundFunc(swapId, unsignedRefundTx, unsignedCheckpointTx);
+    let boltzSignedRefundTx: Transaction;
+    let boltzSignedCheckpointTx: Transaction;
+    try {
+        const result = await refundFunc(
+            swapId,
+            unsignedRefundTx,
+            unsignedCheckpointTx
+        );
+        boltzSignedRefundTx = result.transaction;
+        boltzSignedCheckpointTx = result.checkpoint;
+    } catch (error) {
+        throw new BoltzRefundError(
+            `Boltz rejected refund for swap ${swapId}`,
+            error
+        );
+    }
 
     // Verify Boltz signatures before combining
     const boltzXOnlyPublicKeyHex = hex.encode(boltzXOnlyPublicKey);

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -2671,7 +2671,7 @@ describe("ArkadeSwaps", () => {
                 expect(joinBatch.mock.calls[0][4]).toBe(false);
             });
 
-            it("should throw when Boltz rejects and CLTV still not passed", async () => {
+            it("should skip when Boltz rejects and CLTV still not passed", async () => {
                 const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
 
                 vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
@@ -2685,8 +2685,12 @@ describe("ArkadeSwaps", () => {
                 // Both checks return pre-CLTV
                 vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(10);
 
-                await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
-                    /Boltz rejected VTXO outpoint.*locktime has not passed/
+                await swaps.refundVHTLC(refundableSwap);
+
+                const joinBatch = vi.mocked((swaps as any).joinBatch);
+                expect(joinBatch).not.toHaveBeenCalled();
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({ refunded: false })
                 );
             });
 
@@ -2707,7 +2711,7 @@ describe("ArkadeSwaps", () => {
             });
         });
 
-        it("should throw when a recoverable VTXO is pre-CLTV", async () => {
+        it("should skip a recoverable VTXO when pre-CLTV", async () => {
             vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
             const vtxo = makeVtxo(lockupTxid, 0);
 
@@ -2715,12 +2719,13 @@ describe("ArkadeSwaps", () => {
                 vtxos: [vtxo] as any,
             });
 
-            await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
-                /recoverable VTXO .* cannot be refunded yet/
-            );
+            await swaps.refundVHTLC(refundableSwap);
 
             const joinBatch = vi.mocked((swaps as any).joinBatch);
             expect(joinBatch).not.toHaveBeenCalled();
+            expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                expect.objectContaining({ refunded: false })
+            );
         });
 
         it("should fail early on VHTLC address mismatch", async () => {

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -757,7 +757,7 @@ describe("ArkadeSwaps", () => {
                 });
                 vi.spyOn(arkProvider, "finalizeTx").mockResolvedValueOnce();
                 await expect(swaps.claimVHTLC(pendingSwap)).rejects.toThrow(
-                    "Boltz is trying to scam us"
+                    /VHTLC address mismatch. Expected/
                 );
             });
         });
@@ -960,7 +960,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimBtc(pendingSwap)).rejects.toThrow(
-                    "Destination address is required"
+                    `Swap ${mockArkBtcChainSwap.id}: destination address is required`
                 );
             });
 
@@ -983,7 +983,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimBtc(pendingSwap)).rejects.toThrow(
-                    "Missing swap tree in claim details"
+                    `Swap ${mockArkBtcChainSwap.id}: missing swap tree in claim details`
                 );
             });
 
@@ -1006,7 +1006,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimBtc(pendingSwap)).rejects.toThrow(
-                    "Missing server public key in claim details"
+                    `Swap ${mockArkBtcChainSwap.id}: missing server public key in claim details`
                 );
             });
         });
@@ -1370,7 +1370,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimArk(pendingSwap)).rejects.toThrow(
-                    "Destination address is required"
+                    `Swap ${mockBtcArkChainSwap.id}: destination address is required`
                 );
             });
 
@@ -1393,7 +1393,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimArk(pendingSwap)).rejects.toThrow(
-                    "Missing timeouts in claim details"
+                    `Swap ${mockBtcArkChainSwap.id}: missing timeouts in claim details`
                 );
             });
 
@@ -1416,7 +1416,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimArk(pendingSwap)).rejects.toThrow(
-                    "Missing server public key in claim details"
+                    `Swap ${mockBtcArkChainSwap.id}: missing server public key in claim details`
                 );
             });
 
@@ -1438,7 +1438,7 @@ describe("ArkadeSwaps", () => {
 
                 // act & assert
                 await expect(swaps.claimArk(pendingSwap)).rejects.toThrow(
-                    "No spendable virtual coins found"
+                    `Swap ${mockBtcArkChainSwap.id}: no spendable virtual coins found`
                 );
             });
         });
@@ -2685,9 +2685,7 @@ describe("ArkadeSwaps", () => {
                 // Both checks return pre-CLTV
                 vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(10);
 
-                await expect(
-                    swaps.refundVHTLC(refundableSwap)
-                ).rejects.toThrow(
+                await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
                     /Boltz rejected VTXO outpoint.*locktime has not passed/
                 );
             });
@@ -2703,9 +2701,9 @@ describe("ArkadeSwaps", () => {
                     new Error("local signing failure")
                 );
 
-                await expect(
-                    swaps.refundVHTLC(refundableSwap)
-                ).rejects.toThrow(/local signing failure/);
+                await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
+                    /local signing failure/
+                );
             });
         });
 

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -34,6 +34,7 @@ import { ripemd160 } from "@noble/hashes/legacy.js";
 import { decodeInvoice } from "../src/utils/decoding";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
 import { refundVHTLCwithOffchainTx } from "../src/utils/vhtlc";
+import { BoltzRefundError } from "../src/errors";
 
 // Mock the @arkade-os/sdk modules
 vi.mock("@arkade-os/sdk", async () => {
@@ -2467,9 +2468,16 @@ describe("ArkadeSwaps", () => {
                     refundWithoutReceiver: () =>
                         [{}, new Uint8Array([4]), 0xc0] as any,
                     encode: () => [] as any,
+                    options: {
+                        refundLocktime:
+                            refundableSwap.response.timeoutBlockHeights.refund,
+                    },
                 },
                 vhtlcAddress: refundableSwap.response.address,
             });
+
+            // Default: chain height past CLTV (refundLocktime=17)
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
 
             // stub the actual refund call so we don't need real crypto
             vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
@@ -2505,19 +2513,23 @@ describe("ArkadeSwaps", () => {
             expect(joinBatch.mock.calls[1][1].txid).toBe(otherTxid);
         });
 
-        it("should skip spent VTXOs and refund only unspent ones", async () => {
-            const spentVtxo = { ...makeVtxo(lockupTxid, 0), isSpent: true };
-            const unspentVtxo = makeVtxo(otherTxid, 1);
+        it("should process every VTXO returned by the indexer", async () => {
+            // The indexer is queried with spendableOnly:true so spent VTXOs
+            // should never reach the loop in production. Verify the loop
+            // iterates over every VTXO it receives.
+            const vtxoA = { ...makeVtxo(lockupTxid, 0), isSpent: true };
+            const vtxoB = makeVtxo(otherTxid, 1);
 
             vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
-                vtxos: [spentVtxo, unspentVtxo] as any,
+                vtxos: [vtxoA, vtxoB] as any,
             });
 
             await swaps.refundVHTLC(refundableSwap);
 
             const joinBatch = vi.mocked((swaps as any).joinBatch);
-            expect(joinBatch).toHaveBeenCalledOnce();
-            expect(joinBatch.mock.calls[0][1].txid).toBe(otherTxid);
+            expect(joinBatch).toHaveBeenCalledTimes(2);
+            expect(joinBatch.mock.calls[0][1].txid).toBe(lockupTxid);
+            expect(joinBatch.mock.calls[1][1].txid).toBe(otherTxid);
         });
 
         it("should throw when all VTXOs are spent", async () => {
@@ -2573,6 +2585,12 @@ describe("ArkadeSwaps", () => {
                 createdAt: new Date(),
             });
 
+            beforeEach(() => {
+                // Pre-CLTV: chain tip below refundLocktime (17) so the Boltz
+                // 3-of-3 path is attempted for non-recoverable VTXOs.
+                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(10);
+            });
+
             it("should call refundVHTLCwithOffchainTx for each non-recoverable VTXO", async () => {
                 const vtxoA = makeNonRecoverableVtxo(lockupTxid, 0);
                 const vtxoB = makeNonRecoverableVtxo(otherTxid, 1);
@@ -2609,6 +2627,102 @@ describe("ArkadeSwaps", () => {
                     lockupTxid
                 );
             });
+
+            it("should skip Boltz and use joinBatch when CLTV has passed", async () => {
+                // Chain tip past refundLocktime → refundWithoutReceiver
+                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+
+                const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+
+                vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
+                    vtxos: [vtxo] as any,
+                });
+
+                await swaps.refundVHTLC(refundableSwap);
+
+                expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
+                const joinBatch = vi.mocked((swaps as any).joinBatch);
+                expect(joinBatch).toHaveBeenCalledOnce();
+                // isRecoverable arg must be false for non-recoverable VTXOs
+                expect(joinBatch.mock.calls[0][4]).toBe(false);
+            });
+
+            it("should fall back to joinBatch when Boltz rejects and CLTV has since passed", async () => {
+                const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+
+                vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
+                    vtxos: [vtxo] as any,
+                });
+
+                // Boltz rejects the refund
+                vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                    new BoltzRefundError("outpoint mismatch")
+                );
+
+                // Re-check shows CLTV now satisfied
+                vi.spyOn(swapProvider, "getChainHeight")
+                    .mockResolvedValueOnce(10) // initial check
+                    .mockResolvedValueOnce(100); // re-check after Boltz rejection
+
+                await swaps.refundVHTLC(refundableSwap);
+
+                const joinBatch = vi.mocked((swaps as any).joinBatch);
+                expect(joinBatch).toHaveBeenCalledOnce();
+                expect(joinBatch.mock.calls[0][4]).toBe(false);
+            });
+
+            it("should throw when Boltz rejects and CLTV still not passed", async () => {
+                const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+
+                vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
+                    vtxos: [vtxo] as any,
+                });
+
+                vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                    new BoltzRefundError("outpoint mismatch")
+                );
+
+                // Both checks return pre-CLTV
+                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(10);
+
+                await expect(
+                    swaps.refundVHTLC(refundableSwap)
+                ).rejects.toThrow(
+                    /Boltz rejected VTXO outpoint.*locktime has not passed/
+                );
+            });
+
+            it("should re-throw non-Boltz errors without fallback", async () => {
+                const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+
+                vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
+                    vtxos: [vtxo] as any,
+                });
+
+                vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                    new Error("local signing failure")
+                );
+
+                await expect(
+                    swaps.refundVHTLC(refundableSwap)
+                ).rejects.toThrow(/local signing failure/);
+            });
+        });
+
+        it("should throw when a recoverable VTXO is pre-CLTV", async () => {
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+            const vtxo = makeVtxo(lockupTxid, 0);
+
+            vi.mocked(indexerProvider.getVtxos).mockResolvedValue({
+                vtxos: [vtxo] as any,
+            });
+
+            await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
+                /recoverable VTXO .* cannot be refunded yet/
+            );
+
+            const joinBatch = vi.mocked((swaps as any).joinBatch);
+            expect(joinBatch).not.toHaveBeenCalled();
         });
 
         it("should fail early on VHTLC address mismatch", async () => {


### PR DESCRIPTION
When the Boltz cooperative refund fails (e.g. outpoint mismatch after an
Ark round), fall back to the refundWithoutReceiver tapscript leaf which
only needs sender + server signatures.

- Add BoltzRefundError to distinguish Boltz API rejections from local errors
- Check CLTV locktime via getChainHeight before attempting fallback
- Prefer refundWithoutReceiver for all VTXOs when locktime has passed
- Add tests for CLTV path selection, Boltz fallback, and error cases
- Improve errors with swap ID, where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback refund mechanism using alternative recovery paths when primary submarine refund fails.

* **Bug Fixes**
  * Improved error messages throughout swap operations to include swap identifiers and specific context for better troubleshooting.
  * Enhanced refund handling logic with conditional retry support based on error types and chain state.
  * Tightened diagnostics for spent virtual transaction outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->