### PR TITLE
Retry claim on virtual coins not found

### DIFF
--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -94,6 +94,11 @@ import {
     refundVHTLCwithOffchainTx,
 } from "./utils/vhtlc";
 
+// Retry policy for fetching the lockup VTXO when claiming a swap: the indexer
+// may lag behind the on-chain lockup tx, so retry a few times before giving up.
+const CLAIM_VTXO_RETRY_ATTEMPTS = 3;
+const CLAIM_VTXO_RETRY_DELAY_MS = 500;
+
 /**
  * Unified entry point for Lightning and chain swaps between Arkade, Lightning Network, and Bitcoin.
  *
@@ -500,12 +505,12 @@ export class ArkadeSwaps {
                 `Swap ${pendingSwap.id}: VHTLC address mismatch. Expected ${lockupAddress}, got ${vhtlcAddress}`
             );
 
-        // The indexer may lag behind the lockup tx; retry a few times before giving up.
-        const MAX_ATTEMPTS = 3;
-        const RETRY_DELAY_MS = 500;
-
         let vtxo;
-        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        for (
+            let attempt = 1;
+            attempt <= CLAIM_VTXO_RETRY_ATTEMPTS;
+            attempt++
+        ) {
             const { vtxos } = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
@@ -513,9 +518,9 @@ export class ArkadeSwaps {
                 vtxo = vtxos[0];
                 break;
             }
-            if (attempt < MAX_ATTEMPTS) {
+            if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
                 await new Promise((resolve) =>
-                    setTimeout(resolve, RETRY_DELAY_MS)
+                    setTimeout(resolve, CLAIM_VTXO_RETRY_DELAY_MS)
                 );
             }
         }
@@ -1706,12 +1711,12 @@ export class ArkadeSwaps {
             });
         }
 
-        // The indexer may lag behind the lockup tx; retry a few times before giving up.
-        const MAX_ATTEMPTS = 3;
-        const RETRY_DELAY_MS = 500;
-
         let vtxo;
-        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        for (
+            let attempt = 1;
+            attempt <= CLAIM_VTXO_RETRY_ATTEMPTS;
+            attempt++
+        ) {
             const spendableVtxos = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
                 spendableOnly: true,
@@ -1720,9 +1725,9 @@ export class ArkadeSwaps {
                 vtxo = spendableVtxos.vtxos[0];
                 break;
             }
-            if (attempt < MAX_ATTEMPTS) {
+            if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
                 await new Promise((resolve) =>
-                    setTimeout(resolve, RETRY_DELAY_MS)
+                    setTimeout(resolve, CLAIM_VTXO_RETRY_DELAY_MS)
                 );
             }
         }

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -500,16 +500,31 @@ export class ArkadeSwaps {
                 `Swap ${pendingSwap.id}: VHTLC address mismatch. Expected ${lockupAddress}, got ${vhtlcAddress}`
             );
 
-        // get spendable VTXOs from the lockup address
-        const { vtxos } = await this.indexerProvider.getVtxos({
-            scripts: [hex.encode(vhtlcScript.pkScript)],
-        });
-        if (vtxos.length === 0)
+        // The indexer may lag behind the lockup tx; retry a few times before giving up.
+        const MAX_ATTEMPTS = 3;
+        const RETRY_DELAY_MS = 500;
+
+        let vtxo;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            const { vtxos } = await this.indexerProvider.getVtxos({
+                scripts: [hex.encode(vhtlcScript.pkScript)],
+            });
+            if (vtxos.length > 0) {
+                vtxo = vtxos[0];
+                break;
+            }
+            if (attempt < MAX_ATTEMPTS) {
+                await new Promise((resolve) =>
+                    setTimeout(resolve, RETRY_DELAY_MS)
+                );
+            }
+        }
+
+        if (!vtxo) {
             throw new Error(
                 `Swap ${pendingSwap.id}: no spendable virtual coins found`
             );
-
-        const vtxo = vtxos[0];
+        }
 
         if (vtxo.isSpent) {
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
@@ -1691,18 +1706,32 @@ export class ArkadeSwaps {
             });
         }
 
-        // get spendable VTXOs from the lockup address
-        const spendableVtxos = await this.indexerProvider.getVtxos({
-            scripts: [hex.encode(vhtlcScript.pkScript)],
-            spendableOnly: true,
-        });
+        // The indexer may lag behind the lockup tx; retry a few times before giving up.
+        const MAX_ATTEMPTS = 3;
+        const RETRY_DELAY_MS = 500;
 
-        if (spendableVtxos.vtxos.length === 0)
+        let vtxo;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            const spendableVtxos = await this.indexerProvider.getVtxos({
+                scripts: [hex.encode(vhtlcScript.pkScript)],
+                spendableOnly: true,
+            });
+            if (spendableVtxos.vtxos.length > 0) {
+                vtxo = spendableVtxos.vtxos[0];
+                break;
+            }
+            if (attempt < MAX_ATTEMPTS) {
+                await new Promise((resolve) =>
+                    setTimeout(resolve, RETRY_DELAY_MS)
+                );
+            }
+        }
+
+        if (!vtxo) {
             throw new Error(
                 `Swap ${pendingSwap.id}: no spendable virtual coins found`
             );
-
-        const vtxo = spendableVtxos.vtxos[0];
+        }
 
         const input = {
             ...vtxo,

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -506,11 +506,7 @@ export class ArkadeSwaps {
             );
 
         let vtxo;
-        for (
-            let attempt = 1;
-            attempt <= CLAIM_VTXO_RETRY_ATTEMPTS;
-            attempt++
-        ) {
+        for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
             const { vtxos } = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
@@ -1712,11 +1708,7 @@ export class ArkadeSwaps {
         }
 
         let vtxo;
-        for (
-            let attempt = 1;
-            attempt <= CLAIM_VTXO_RETRY_ATTEMPTS;
-            attempt++
-        ) {
+        for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
             const spendableVtxos = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
                 spendableOnly: true,

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -760,6 +760,119 @@ describe("ArkadeSwaps", () => {
                     /VHTLC address mismatch. Expected/
                 );
             });
+
+            it("should throw error when no spendable VTXOs found after 3 attempts", async () => {
+                vi.useFakeTimers();
+                try {
+                    // arrange
+                    const pendingSwap: BoltzReverseSwap = {
+                        id: mock.id,
+                        type: "reverse",
+                        createdAt: Date.now(),
+                        preimage: hex.encode(preimage),
+                        request: createReverseSwapRequest,
+                        response: {
+                            ...createReverseSwapResponse,
+                            lockupAddress: mockVHTLC.vhtlcAddress,
+                        },
+                        status: "swap.created",
+                    };
+                    vi.spyOn(arkProvider, "getInfo").mockResolvedValueOnce(
+                        mockArkInfo
+                    );
+                    vi.spyOn(swaps, "createVHTLCScript").mockReturnValueOnce(
+                        mockVHTLC
+                    );
+                    vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                        vtxos: [],
+                    });
+
+                    const promise = swaps.claimVHTLC(pendingSwap);
+                    // attach a no-op handler so the rejection isn't flagged as
+                    // unhandled while the fake timers are advancing
+                    promise.catch(() => {});
+
+                    await vi.advanceTimersByTimeAsync(1000); // fail + 500ms + fails + 500ms + fails and throws
+
+                    // act & assert
+                    await expect(promise).rejects.toThrow(
+                        `Swap ${mock.id}: no spendable virtual coins found`
+                    );
+                } finally {
+                    vi.useRealTimers();
+                }
+            });
+
+            it("should retry getVtxos and succeed when a VTXO appears on a later attempt", async () => {
+                vi.useFakeTimers();
+                try {
+                    // arrange
+                    const pendingSwap: BoltzReverseSwap = {
+                        id: mock.id,
+                        type: "reverse",
+                        createdAt: Date.now(),
+                        preimage: hex.encode(preimage),
+                        request: createReverseSwapRequest,
+                        response: {
+                            ...createReverseSwapResponse,
+                            lockupAddress: mockVHTLC.vhtlcAddress,
+                        },
+                        status: "swap.created",
+                    };
+                    vi.spyOn(arkProvider, "getInfo").mockResolvedValueOnce(
+                        mockArkInfo
+                    );
+                    vi.spyOn(swaps, "createVHTLCScript").mockReturnValueOnce(
+                        mockVHTLC
+                    );
+                    vi.mocked(wallet.getAddress).mockResolvedValue(
+                        mock.address.ark
+                    );
+
+                    // recoverable VTXO — takes the joinBatch path
+                    const vtxo = {
+                        txid: hex.encode(randomBytes(32)),
+                        vout: 0,
+                        value: mock.amount,
+                        status: {
+                            confirmed: true,
+                            blockHeight: 100,
+                            blockHash: "abc",
+                        },
+                        virtualStatus: { state: "swept" as const },
+                        isSpent: false,
+                        isUnrolled: false,
+                        createdAt: new Date(),
+                    };
+                    vi.spyOn(indexerProvider, "getVtxos")
+                        .mockResolvedValueOnce({ vtxos: [] })
+                        .mockResolvedValueOnce({ vtxos: [vtxo] as any });
+
+                    const joinBatchSpy = vi
+                        .spyOn(swaps as any, "joinBatch")
+                        .mockResolvedValue(undefined);
+
+                    // act
+                    const promise = swaps.claimVHTLC(pendingSwap);
+                    promise.catch(() => {});
+
+                    // first getVtxos returns empty → wait 500ms → second returns VTXO
+                    await vi.advanceTimersByTimeAsync(500);
+
+                    // assert
+                    await expect(promise).resolves.toBeUndefined();
+                    expect(indexerProvider.getVtxos).toHaveBeenCalledTimes(2);
+                    expect(joinBatchSpy).toHaveBeenCalledOnce();
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            id: mock.id,
+                            status: "transaction.claimed",
+                        })
+                    );
+                } finally {
+                    vi.useRealTimers();
+                }
+            });
         });
 
         describe("waitAndClaim", () => {
@@ -1420,26 +1533,107 @@ describe("ArkadeSwaps", () => {
                 );
             });
 
-            it("should throw error when no spendable VTXOs found", async () => {
-                // arrange
-                const pendingSwap: BoltzChainSwap = {
-                    ...mockBtcArkChainSwap,
-                    preimage: hex.encode(mockPreimage),
-                };
-                vi.spyOn(arkProvider, "getInfo").mockResolvedValueOnce(
-                    mockArkInfo
-                );
-                vi.spyOn(swaps, "createVHTLCScript").mockReturnValueOnce(
-                    mockBtcArkVHTLC
-                );
-                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValueOnce({
-                    vtxos: [],
-                });
+            it("should throw error when no spendable VTXOs found after 3 attempts", async () => {
+                vi.useFakeTimers();
+                try {
+                    // arrange
+                    const pendingSwap: BoltzChainSwap = {
+                        ...mockBtcArkChainSwap,
+                        preimage: hex.encode(mockPreimage),
+                    };
+                    vi.spyOn(arkProvider, "getInfo").mockResolvedValueOnce(
+                        mockArkInfo
+                    );
+                    vi.spyOn(swaps, "createVHTLCScript").mockReturnValueOnce(
+                        mockBtcArkVHTLC
+                    );
+                    vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                        vtxos: [],
+                    });
 
-                // act & assert
-                await expect(swaps.claimArk(pendingSwap)).rejects.toThrow(
-                    `Swap ${mockBtcArkChainSwap.id}: no spendable virtual coins found`
-                );
+                    const promise = swaps.claimArk(pendingSwap);
+                    // attach a no-op handler so the rejection isn't flagged as
+                    // unhandled while the fake timers are advancing
+                    promise.catch(() => {});
+
+                    await vi.advanceTimersByTimeAsync(1000); // fail + 500ms + fails + 500ms + fails and throws
+
+                    // act & assert
+                    await expect(promise).rejects.toThrow(
+                        `Swap ${mockBtcArkChainSwap.id}: no spendable virtual coins found`
+                    );
+                } finally {
+                    vi.useRealTimers();
+                }
+            });
+
+            it("should retry getVtxos and succeed when a VTXO appears on a later attempt", async () => {
+                vi.useFakeTimers();
+                try {
+                    // arrange
+                    const pendingSwap: BoltzChainSwap = {
+                        ...mockBtcArkChainSwap,
+                        preimage: hex.encode(mockPreimage),
+                    };
+                    vi.spyOn(arkProvider, "getInfo").mockResolvedValueOnce(
+                        mockArkInfo
+                    );
+                    vi.spyOn(swaps, "createVHTLCScript").mockReturnValueOnce(
+                        mockBtcArkVHTLC
+                    );
+                    vi.mocked(wallet.getAddress).mockResolvedValue(
+                        mock.address.ark
+                    );
+
+                    // recoverable VTXO — takes the joinBatch path
+                    const vtxo = {
+                        txid: hex.encode(randomBytes(32)),
+                        vout: 0,
+                        value: mock.amount,
+                        status: {
+                            confirmed: true,
+                            blockHeight: 100,
+                            blockHash: "abc",
+                        },
+                        virtualStatus: { state: "swept" as const },
+                        isSpent: false,
+                        isUnrolled: false,
+                        createdAt: new Date(),
+                    };
+                    vi.spyOn(indexerProvider, "getVtxos")
+                        .mockResolvedValueOnce({ vtxos: [] })
+                        .mockResolvedValueOnce({ vtxos: [vtxo] as any });
+
+                    const joinBatchSpy = vi
+                        .spyOn(swaps as any, "joinBatch")
+                        .mockResolvedValue(undefined);
+                    vi.spyOn(
+                        swapProvider,
+                        "getSwapStatus"
+                    ).mockResolvedValueOnce({
+                        status: "transaction.claimed",
+                    });
+
+                    // act
+                    const promise = swaps.claimArk(pendingSwap);
+                    promise.catch(() => {});
+
+                    // first getVtxos returns empty → wait 500ms → second returns VTXO
+                    await vi.advanceTimersByTimeAsync(500);
+
+                    // assert
+                    await expect(promise).resolves.toBeUndefined();
+                    expect(indexerProvider.getVtxos).toHaveBeenCalledTimes(2);
+                    expect(joinBatchSpy).toHaveBeenCalledOnce();
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            id: mockBtcArkChainSwap.id,
+                            status: "transaction.claimed",
+                        })
+                    );
+                } finally {
+                    vi.useRealTimers();
+                }
             });
         });
 


### PR DESCRIPTION
Issue reproducible on current master:

1. create lightning invoice
2. pay it
3. the claim fails consistently with `no spendable virtual coins found`
4. a reload or manual claim works

The indexer seems to have a very short lag compared to the Boltz's state change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Improved swap claiming reliability** - Claim operations for reverse swaps and blockchain-to-Ark chain swaps now include automatic retry logic for transaction lookups. When the indexer is temporarily behind, the system automatically waits and retries before ultimately failing, significantly reducing transaction failures caused by network timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->