### PR TITLE
Add user-initiated submarine VHTLC recovery APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist
 # AI
 CLAUDE.md
 .claude
+*.agents.md
 *.agent.md

--- a/README.md
+++ b/README.md
@@ -191,6 +191,28 @@ const unsubscribe = manager.subscribeToSwapUpdates(
 );
 ```
 
+### Submarine Fund Recovery
+
+If a Lightning payment fails and funds get stranded in a VHTLC, you can recover them manually:
+
+```typescript
+// Scan all local swaps for recoverable funds
+const candidates = await swaps.scanRecoverableSubmarineSwaps();
+// candidates[i].status: "recoverable" | "pre_cltv" | "none" | "already_spent" | "invalid_swap"
+
+// Recover all at once
+const results = await swaps.recoverAllSubmarineFunds(candidates.map(c => c.swap));
+
+// Or inspect / recover a single swap
+const info = await swaps.inspectSubmarineRecovery(swap);
+if (info.status === 'recoverable') {
+  await swaps.recoverSubmarineFunds(swap);
+}
+```
+
+> [!NOTE]
+> This only scans swaps stored in your local repository. It does not discover swaps that exist on Boltz but are missing locally.
+
 ### Cleanup
 
 ```typescript

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -18,6 +18,7 @@ import {
     isRecoverable,
     ArkTxInput,
     Identity,
+    VirtualCoin,
 } from "@arkade-os/sdk";
 import type {
     Chain,
@@ -37,6 +38,8 @@ import type {
     SendLightningPaymentResponse,
     ArkToBtcResponse,
     BtcToArkResponse,
+    SubmarineRecoveryInfo,
+    SubmarineRecoveryResult,
 } from "./types";
 import {
     BoltzSwapProvider,
@@ -46,6 +49,8 @@ import {
     CreateReverseSwapRequest,
     CreateChainSwapRequest,
     isSubmarineFinalStatus,
+    isSubmarineSuccessStatus,
+    isSubmarineRefundableStatus,
     isReverseFinalStatus,
     isChainFinalStatus,
     isRestoredReverseSwap,
@@ -93,6 +98,57 @@ import {
     joinBatch,
     refundVHTLCwithOffchainTx,
 } from "./utils/vhtlc";
+
+type SubmarineVHTLCDiagnostic = {
+    totalVtxoCount: number;
+    allSpent: boolean;
+};
+
+type SubmarineVHTLCContext = {
+    arkInfo: ArkInfo;
+    vhtlcScript: VHTLC.Script;
+    vhtlcAddress: string;
+    vhtlcPkScriptHex: string;
+    timeoutBlockHeights: NonNullable<
+        BoltzSubmarineSwap["response"]["timeoutBlockHeights"]
+    >;
+    ourXOnlyPublicKey: Uint8Array;
+    serverXOnlyPublicKey: Uint8Array;
+    boltzXOnlyPublicKey: Uint8Array;
+};
+
+type SubmarineVHTLCLookup = SubmarineVHTLCContext & {
+    refundableVtxos: VirtualCoin[];
+    diagnostic?: SubmarineVHTLCDiagnostic;
+};
+
+type SubmarineScanPrepared =
+    | {
+          swap: BoltzSubmarineSwap;
+          context: SubmarineVHTLCContext;
+      }
+    | {
+          swap: BoltzSubmarineSwap;
+          error: string;
+      };
+
+type RefundLocktimeStatus = {
+    satisfied: boolean;
+    currentBlockHeight?: number;
+    currentTimestamp?: number;
+    referenceLabel: "currentBlockHeight" | "currentTimestamp";
+    referenceValue: number;
+};
+
+const dedupeVtxos = (vtxos: VirtualCoin[]): VirtualCoin[] => [
+    ...new Map(
+        vtxos.map((vtxo) => [`${vtxo.txid}:${vtxo.vout}`, vtxo] as const)
+    ).values(),
+];
+
+const LOCKTIME_THRESHOLD = 500_000_000;
+const isTimestampLocktime = (locktime: number): boolean =>
+    locktime >= LOCKTIME_THRESHOLD;
 
 // Retry policy for fetching the lockup VTXO when claiming a swap: the indexer
 // may lag behind the on-chain lockup tx, so retry a few times before giving up.
@@ -779,52 +835,53 @@ export class ArkadeSwaps {
     }
 
     /**
-     * Refunds the VHTLC for a failed submarine swap, returning locked funds to the wallet.
-     * Uses multi-party signatures (user + Boltz + server) for non-recoverable VTXOs.
-     * @param pendingSwap - The submarine swap to refund.
-     * @throws {Error} If preimage hash is unavailable, VHTLC not found, or already spent.
+     * Reconstruct a submarine swap's VHTLC script from stored data. This does
+     * not query the indexer, so bulk scans can build every script first and
+     * then use batched VTXO lookups.
+     *
+     * @throws {Error} If preimage hash is unavailable, the swap response is
+     *   incomplete, the script can't be built, or the reconstructed address
+     *   doesn't match the one Boltz returned.
      */
-    async refundVHTLC(pendingSwap: BoltzSubmarineSwap): Promise<void> {
-        const preimageHash = pendingSwap.request.invoice
-            ? getInvoicePaymentHash(pendingSwap.request.invoice)
-            : pendingSwap.preimageHash;
-
+    private async buildSubmarineVHTLCContext(
+        swap: BoltzSubmarineSwap,
+        arkInfo?: ArkInfo
+    ): Promise<SubmarineVHTLCContext> {
+        const preimageHash = swap.request.invoice
+            ? getInvoicePaymentHash(swap.request.invoice)
+            : swap.preimageHash;
         if (!preimageHash)
             throw new Error(
-                `Swap ${pendingSwap.id}: preimage hash is required to refund VHTLC`
+                `Swap ${swap.id}: preimage hash is required to refund VHTLC`
             );
 
-        // prepare keys and script (independent of VTXO selection)
-        const arkInfo = await this.arkProvider.getInfo();
-        const address = await this.wallet.getAddress();
-        if (!address) throw new Error("Failed to get ark address from wallet");
+        const resolvedArkInfo = arkInfo ?? (await this.arkProvider.getInfo());
 
         const ourXOnlyPublicKey = normalizeToXOnlyKey(
             await this.wallet.identity.xOnlyPublicKey(),
             "our",
-            pendingSwap.id
+            swap.id
         );
-
         const serverXOnlyPublicKey = normalizeToXOnlyKey(
-            hex.decode(arkInfo.signerPubkey),
+            hex.decode(resolvedArkInfo.signerPubkey),
             "server",
-            pendingSwap.id
+            swap.id
         );
 
-        const { claimPublicKey, timeoutBlockHeights } = pendingSwap.response;
+        const { claimPublicKey, timeoutBlockHeights } = swap.response;
         if (!claimPublicKey || !timeoutBlockHeights)
             throw new Error(
-                `Swap ${pendingSwap.id}: incomplete submarine swap response`
+                `Swap ${swap.id}: incomplete submarine swap response`
             );
 
         const boltzXOnlyPublicKey = normalizeToXOnlyKey(
             hex.decode(claimPublicKey),
             "boltz",
-            pendingSwap.id
+            swap.id
         );
 
         const { vhtlcScript, vhtlcAddress } = this.createVHTLCScript({
-            network: arkInfo.network,
+            network: resolvedArkInfo.network,
             preimageHash: hex.decode(preimageHash),
             receiverPubkey: hex.encode(boltzXOnlyPublicKey),
             senderPubkey: hex.encode(ourXOnlyPublicKey),
@@ -834,53 +891,202 @@ export class ArkadeSwaps {
 
         if (!vhtlcScript.claimScript)
             throw new Error(
-                `Swap ${pendingSwap.id}: failed to create VHTLC script for submarine swap`
+                `Swap ${swap.id}: failed to create VHTLC script for submarine swap`
             );
 
-        // sanity check: reconstructed address must match the swap response
-        if (vhtlcAddress !== pendingSwap.response.address)
+        if (vhtlcAddress !== swap.response.address)
             throw new Error(
-                `VHTLC address mismatch for swap ${pendingSwap.id}: ` +
-                    `expected ${pendingSwap.response.address}, got ${vhtlcAddress}`
+                `VHTLC address mismatch for swap ${swap.id}: ` +
+                    `expected ${swap.response.address}, got ${vhtlcAddress}`
             );
 
-        // Query VTXOs using the locally-reconstructed script (not the Boltz
-        // response address). The VHTLC script is unique per swap, so every
-        // refundable VTXO at this script belongs to this swap and must be
-        // processed locally. The indexer exposes "spendable" and
-        // "recoverable" VTXOs through separate filters, so merge both views
-        // before deciding whether the swap still has refundable funds.
+        // Use the locally-reconstructed script, not the Boltz response
+        // address. The VHTLC script is unique per swap, so every refundable
+        // VTXO at this script belongs to this swap.
         const vhtlcPkScriptHex = hex.encode(vhtlcScript.pkScript);
+
+        return {
+            arkInfo: resolvedArkInfo,
+            vhtlcScript,
+            vhtlcAddress,
+            vhtlcPkScriptHex,
+            timeoutBlockHeights,
+            ourXOnlyPublicKey,
+            serverXOnlyPublicKey,
+            boltzXOnlyPublicKey,
+        };
+    }
+
+    /**
+     * Reconstruct a submarine swap's VHTLC script from stored data and look
+     * up its VTXOs at the indexer. Side-effect free; shared by `refundVHTLC`
+     * (spending path) and `inspectSubmarineRecovery` (diagnostic path).
+     *
+     * `refundableVtxos` merges spendable + recoverable indexer queries
+     * (deduped by outpoint). When that set is empty, a third query
+     * populates `diagnostic` so callers can distinguish "never funded",
+     * "already spent", and "preconfirmed-only".
+     */
+    private async lookupSubmarineVHTLC(
+        swap: BoltzSubmarineSwap,
+        arkInfo?: ArkInfo
+    ): Promise<SubmarineVHTLCLookup> {
+        const context = await this.buildSubmarineVHTLCContext(swap, arkInfo);
+        // Query VTXOs using the locally-reconstructed script (not the Boltz
+        // response address). The indexer
+        // exposes "spendable" and "recoverable" VTXOs through separate
+        // filters, so merge both views.
         const [spendableResult, recoverableResult] = await Promise.all([
             this.indexerProvider.getVtxos({
-                scripts: [vhtlcPkScriptHex],
+                scripts: [context.vhtlcPkScriptHex],
                 spendableOnly: true,
             }),
             this.indexerProvider.getVtxos({
-                scripts: [vhtlcPkScriptHex],
+                scripts: [context.vhtlcPkScriptHex],
                 recoverableOnly: true,
             }),
         ]);
-        const refundableVtxos = [
-            ...new Map(
-                [...spendableResult.vtxos, ...recoverableResult.vtxos].map(
-                    (vtxo) => [`${vtxo.txid}:${vtxo.vout}`, vtxo] as const
-                )
-            ).values(),
-        ];
+        const refundableVtxos = dedupeVtxos([
+            ...spendableResult.vtxos,
+            ...recoverableResult.vtxos,
+        ]);
+
+        // Only query "all VTXOs" when the refundable set is empty — that's
+        // the only path where we need to distinguish empty cases.
+        let diagnostic: SubmarineVHTLCDiagnostic | undefined;
+        if (refundableVtxos.length === 0) {
+            const { vtxos: allVtxos } = await this.indexerProvider.getVtxos({
+                scripts: [context.vhtlcPkScriptHex],
+            });
+            diagnostic = {
+                totalVtxoCount: allVtxos.length,
+                allSpent:
+                    allVtxos.length > 0 &&
+                    allVtxos.every((vtxo) => vtxo.isSpent),
+            };
+        }
+
+        return {
+            ...context,
+            refundableVtxos,
+            diagnostic,
+        };
+    }
+
+    private async getRefundLocktimeStatus(
+        refundLocktime: number,
+        currentBlockHeight?: number
+    ): Promise<RefundLocktimeStatus> {
+        if (isTimestampLocktime(refundLocktime)) {
+            const currentTimestamp = Math.floor(Date.now() / 1000);
+            return {
+                satisfied: currentTimestamp >= refundLocktime,
+                currentTimestamp,
+                referenceLabel: "currentTimestamp",
+                referenceValue: currentTimestamp,
+            };
+        }
+
+        const height =
+            currentBlockHeight ?? (await this.swapProvider.getChainHeight());
+        return {
+            satisfied: height >= refundLocktime,
+            currentBlockHeight: height,
+            referenceLabel: "currentBlockHeight",
+            referenceValue: height,
+        };
+    }
+
+    private async submarineRecoveryInfoFromLookup(
+        swap: BoltzSubmarineSwap,
+        lookup: Pick<
+            SubmarineVHTLCLookup,
+            "timeoutBlockHeights" | "refundableVtxos" | "diagnostic"
+        >,
+        currentBlockHeight?: number
+    ): Promise<SubmarineRecoveryInfo> {
+        const { refundableVtxos, diagnostic, timeoutBlockHeights } = lookup;
+
+        if (refundableVtxos.length > 0) {
+            const locktimeStatus = await this.getRefundLocktimeStatus(
+                timeoutBlockHeights.refund,
+                currentBlockHeight
+            );
+            const amountSats = refundableVtxos.reduce(
+                (sum, vtxo) => sum + Number(vtxo.value),
+                0
+            );
+            return {
+                swap,
+                status: locktimeStatus.satisfied ? "recoverable" : "pre_cltv",
+                vtxoCount: refundableVtxos.length,
+                amountSats,
+                refundLocktime: timeoutBlockHeights.refund,
+                currentBlockHeight: locktimeStatus.currentBlockHeight,
+            };
+        }
+
+        // No refundable VTXOs. If diagnostic was not fetched (bulk scan path),
+        // classify this as "none" without issuing a third indexer query.
+        if (!diagnostic || diagnostic.totalVtxoCount === 0) {
+            return {
+                swap,
+                status: "none",
+                vtxoCount: 0,
+                amountSats: 0,
+                refundLocktime: timeoutBlockHeights.refund,
+            };
+        }
+        if (diagnostic.allSpent) {
+            return {
+                swap,
+                status: "already_spent",
+                vtxoCount: 0,
+                amountSats: 0,
+                refundLocktime: timeoutBlockHeights.refund,
+            };
+        }
+        // VTXOs exist but none refundable — preconfirmed-only state.
+        return {
+            swap,
+            status: "none",
+            vtxoCount: 0,
+            amountSats: 0,
+            refundLocktime: timeoutBlockHeights.refund,
+        };
+    }
+
+    /**
+     * Refunds the VHTLC for a failed submarine swap, returning locked funds to the wallet.
+     * Uses multi-party signatures (user + Boltz + server) for non-recoverable VTXOs.
+     * @param pendingSwap - The submarine swap to refund.
+     * @throws {Error} If preimage hash is unavailable, VHTLC not found, or already spent.
+     */
+    async refundVHTLC(
+        pendingSwap: BoltzSubmarineSwap,
+        cachedArkInfo?: ArkInfo
+    ): Promise<void> {
+        const address = await this.wallet.getAddress();
+        if (!address) throw new Error("Failed to get ark address from wallet");
+
+        const {
+            arkInfo,
+            vhtlcScript,
+            timeoutBlockHeights,
+            ourXOnlyPublicKey,
+            serverXOnlyPublicKey,
+            boltzXOnlyPublicKey,
+            refundableVtxos,
+            diagnostic,
+        } = await this.lookupSubmarineVHTLC(pendingSwap, cachedArkInfo);
 
         if (refundableVtxos.length === 0) {
-            // Distinguish "all spent" from "never funded" (or not yet
-            // refundable) for diagnostics.
-            const { vtxos: allVtxos } = await this.indexerProvider.getVtxos({
-                scripts: [vhtlcPkScriptHex],
-            });
-            if (allVtxos.length === 0) {
+            if (!diagnostic || diagnostic.totalVtxoCount === 0) {
                 throw new Error(
                     `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.address}`
                 );
             }
-            if (allVtxos.every((vtxo) => vtxo.isSpent)) {
+            if (diagnostic.allSpent) {
                 throw new Error(
                     `Swap ${pendingSwap.id}: VHTLC is already spent`
                 );
@@ -892,9 +1098,10 @@ export class ArkadeSwaps {
 
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
-        const refundLocktime = BigInt(timeoutBlockHeights.refund);
-        const currentBlockHeight = await this.swapProvider.getChainHeight();
-        const cltvSatisfied = BigInt(currentBlockHeight) >= refundLocktime;
+        const locktimeStatus = await this.getRefundLocktimeStatus(
+            timeoutBlockHeights.refund
+        );
+        const cltvSatisfied = locktimeStatus.satisfied;
 
         // Refund every unspent VTXO at the contract address.
         // Throttle between Boltz API calls to avoid 429 rate-limiting.
@@ -935,7 +1142,8 @@ export class ArkadeSwaps {
                     `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
                         `(refundLocktime=${timeoutBlockHeights.refund}, ` +
-                        `currentBlockHeight=${currentBlockHeight}). Refund will be retried after locktime.`
+                        `${locktimeStatus.referenceLabel}=${locktimeStatus.referenceValue}). ` +
+                        `Refund will be retried after locktime.`
                 );
                 skippedCount++;
                 continue;
@@ -973,14 +1181,17 @@ export class ArkadeSwaps {
                     throw error;
                 }
 
-                // Re-check chain tip — it may have advanced while talking
-                // to Boltz.
-                const tipNow = await this.swapProvider.getChainHeight();
-                if (BigInt(tipNow) < refundLocktime) {
+                // Re-check the locktime reference — it may have advanced while
+                // talking to Boltz.
+                const updatedLocktimeStatus =
+                    await this.getRefundLocktimeStatus(
+                        timeoutBlockHeights.refund
+                    );
+                if (!updatedLocktimeStatus.satisfied) {
                     logger.error(
                         `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
-                            `(currentBlockHeight=${tipNow}, ` +
+                            `(${updatedLocktimeStatus.referenceLabel}=${updatedLocktimeStatus.referenceValue}, ` +
                             `locktime=${timeoutBlockHeights.refund}). ` +
                             `Refund will be retried after locktime.`
                     );
@@ -1007,14 +1218,263 @@ export class ArkadeSwaps {
             }
         }
 
-        // update the pending swap on storage
-        const fullyRefunded = skippedCount === 0;
-        await updateSubmarineSwapStatus(
-            pendingSwap,
-            pendingSwap.status, // Keep current status
-            this.savePendingSubmarineSwap.bind(this),
-            { refundable: true, refunded: fullyRefunded }
+        // Skip the flag update when this is a manual recovery on a
+        // successfully-claimed swap (e.g. user accidentally double-funded
+        // the lockup address). Flipping refunded:true on a
+        // transaction.claimed swap would muddle its history. Legitimate
+        // failure-refund statuses still update normally.
+        if (!isSubmarineSuccessStatus(pendingSwap.status)) {
+            const fullyRefunded = skippedCount === 0;
+            await updateSubmarineSwapStatus(
+                pendingSwap,
+                pendingSwap.status, // Keep current status
+                this.savePendingSubmarineSwap.bind(this),
+                { refundable: true, refunded: fullyRefunded }
+            );
+        }
+    }
+
+    /**
+     * Inspect a submarine swap's lockup address for recoverable funds.
+     *
+     * Side-effect free. Returns a structured snapshot the UI can use to
+     * decide whether to offer the user a recovery action — it will not
+     * trigger any signing or persistence.
+     *
+     * Only `transaction.claimed` (success with possible stranded extras)
+     * and refundable failure statuses are recovery candidates. Pending
+     * statuses (`invoice.set`, `transaction.mempool`, …) are returned as
+     * `invalid_swap`; this API is for recovery, not a generic VTXO probe.
+     *
+     * @param swap - The submarine swap to inspect.
+     */
+    async inspectSubmarineRecovery(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRecoveryInfo> {
+        if (
+            !isSubmarineSuccessStatus(swap.status) &&
+            !isSubmarineRefundableStatus(swap.status)
+        ) {
+            return {
+                swap,
+                status: "invalid_swap",
+                vtxoCount: 0,
+                amountSats: 0,
+                refundLocktime: swap.response.timeoutBlockHeights?.refund,
+                error: `Swap status ${swap.status} is not a recovery candidate`,
+            };
+        }
+
+        let lookup;
+        try {
+            lookup = await this.lookupSubmarineVHTLC(swap);
+        } catch (err) {
+            return {
+                swap,
+                status: "invalid_swap",
+                vtxoCount: 0,
+                amountSats: 0,
+                refundLocktime: swap.response.timeoutBlockHeights?.refund,
+                error: err instanceof Error ? err.message : String(err),
+            };
+        }
+
+        return this.submarineRecoveryInfoFromLookup(swap, lookup);
+    }
+
+    /**
+     * Scan all locally-known submarine swaps for recoverable VHTLC funds.
+     *
+     * Loads submarine swaps from the repository, filters to recovery
+     * candidates (`transaction.claimed` plus refundable failure
+     * statuses), reconstructs their scripts, and performs one batched
+     * spendable query plus one batched recoverable query. Pending swaps are
+     * skipped entirely — they appear in the local repository but cannot
+     * be in a recovery state yet.
+     *
+     * Side-effect free: does not mutate the repository, does not sign,
+     * and does not query Boltz swap status.
+     */
+    async scanRecoverableSubmarineSwaps(): Promise<SubmarineRecoveryInfo[]> {
+        const submarineSwaps =
+            await this.swapRepository.getAllSwaps<BoltzSubmarineSwap>({
+                type: "submarine",
+            });
+
+        const candidates = submarineSwaps.filter(
+            (swap) =>
+                isSubmarineSuccessStatus(swap.status) ||
+                isSubmarineRefundableStatus(swap.status)
         );
+
+        let arkInfo: ArkInfo | undefined;
+        let arkInfoError: string | undefined;
+        if (candidates.length > 0) {
+            try {
+                arkInfo = await this.arkProvider.getInfo();
+            } catch (err) {
+                arkInfoError = err instanceof Error ? err.message : String(err);
+            }
+        }
+
+        const prepared: SubmarineScanPrepared[] = await Promise.all(
+            candidates.map(async (swap) => {
+                if (arkInfoError) {
+                    return {
+                        swap,
+                        error: arkInfoError,
+                    };
+                }
+
+                try {
+                    return {
+                        swap,
+                        context: await this.buildSubmarineVHTLCContext(
+                            swap,
+                            arkInfo
+                        ),
+                    };
+                } catch (err) {
+                    return {
+                        swap,
+                        error: err instanceof Error ? err.message : String(err),
+                    };
+                }
+            })
+        );
+
+        const valid = prepared.filter(
+            (
+                item
+            ): item is Extract<SubmarineScanPrepared, { context: unknown }> =>
+                "context" in item
+        );
+        const scripts = [
+            ...new Set(valid.map(({ context }) => context.vhtlcPkScriptHex)),
+        ];
+
+        const refundableByScript = new Map<string, VirtualCoin[]>();
+        if (scripts.length > 0) {
+            const [spendableResult, recoverableResult] = await Promise.all([
+                this.indexerProvider.getVtxos({
+                    scripts,
+                    spendableOnly: true,
+                }),
+                this.indexerProvider.getVtxos({
+                    scripts,
+                    recoverableOnly: true,
+                }),
+            ]);
+
+            for (const vtxo of dedupeVtxos([
+                ...spendableResult.vtxos,
+                ...recoverableResult.vtxos,
+            ])) {
+                const script = vtxo.script?.toLowerCase();
+                if (!script) continue;
+                const existing = refundableByScript.get(script) ?? [];
+                existing.push(vtxo);
+                refundableByScript.set(script, existing);
+            }
+        }
+
+        const hasBlockBasedRefundableVtxos = valid.some(({ context }) => {
+            return (
+                !isTimestampLocktime(context.timeoutBlockHeights.refund) &&
+                (refundableByScript.get(context.vhtlcPkScriptHex.toLowerCase())
+                    ?.length ?? 0) > 0
+            );
+        });
+        const currentBlockHeight = hasBlockBasedRefundableVtxos
+            ? await this.swapProvider.getChainHeight()
+            : undefined;
+
+        return Promise.all(
+            prepared.map((item) => {
+                if ("error" in item) {
+                    return Promise.resolve({
+                        swap: item.swap,
+                        status: "invalid_swap" as const,
+                        vtxoCount: 0,
+                        amountSats: 0,
+                        refundLocktime:
+                            item.swap.response.timeoutBlockHeights?.refund,
+                        error: item.error,
+                    });
+                }
+
+                const refundableVtxos =
+                    refundableByScript.get(
+                        item.context.vhtlcPkScriptHex.toLowerCase()
+                    ) ?? [];
+                return this.submarineRecoveryInfoFromLookup(
+                    item.swap,
+                    {
+                        ...item.context,
+                        refundableVtxos,
+                    },
+                    currentBlockHeight
+                );
+            })
+        );
+    }
+
+    /**
+     * Recover funds locked at a single submarine swap's VHTLC address.
+     *
+     * Thin wrapper around `refundVHTLC` for callers that have already
+     * confirmed (e.g. via `inspectSubmarineRecovery`) that funds are
+     * present. Centralises the spending logic in one place — flag-write
+     * behavior matches `refundVHTLC` (no-op for `transaction.claimed`,
+     * normal flag updates for failure statuses).
+     */
+    async recoverSubmarineFunds(
+        swap: BoltzSubmarineSwap,
+        arkInfo?: ArkInfo
+    ): Promise<void> {
+        await this.refundVHTLC(swap, arkInfo);
+    }
+
+    /**
+     * Recover funds for a batch of submarine swaps.
+     *
+     * Each swap's recovery is independent — a failure on one swap does
+     * not abort the rest, and the caller receives a per-swap result so
+     * they can present partial outcomes in the UI. Recovery runs
+     * sequentially to avoid hammering Boltz / the indexer with parallel
+     * batch joins.
+     */
+    async recoverAllSubmarineFunds(
+        swaps: BoltzSubmarineSwap[]
+    ): Promise<SubmarineRecoveryResult[]> {
+        const results: SubmarineRecoveryResult[] = [];
+        let arkInfo: ArkInfo | undefined;
+        try {
+            if (swaps.length > 0) {
+                arkInfo = await this.arkProvider.getInfo();
+            }
+        } catch (err) {
+            const error = err instanceof Error ? err.message : String(err);
+            return swaps.map((swap) => ({
+                swapId: swap.id,
+                recovered: false,
+                error,
+            }));
+        }
+
+        for (const swap of swaps) {
+            try {
+                await this.recoverSubmarineFunds(swap, arkInfo);
+                results.push({ swapId: swap.id, recovered: true });
+            } catch (err) {
+                results.push({
+                    swapId: swap.id,
+                    recovered: false,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            }
+        }
+        return results;
     }
 
     /**
@@ -2482,6 +2942,14 @@ export interface IArkadeSwaps extends AsyncDisposable {
     ): Promise<BoltzReverseSwap>;
     claimVHTLC(pendingSwap: BoltzReverseSwap): Promise<void>;
     refundVHTLC(pendingSwap: BoltzSubmarineSwap): Promise<void>;
+    inspectSubmarineRecovery(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRecoveryInfo>;
+    scanRecoverableSubmarineSwaps(): Promise<SubmarineRecoveryInfo[]>;
+    recoverSubmarineFunds(swap: BoltzSubmarineSwap): Promise<void>;
+    recoverAllSubmarineFunds(
+        swaps: BoltzSubmarineSwap[]
+    ): Promise<SubmarineRecoveryResult[]>;
     waitAndClaim(pendingSwap: BoltzReverseSwap): Promise<{ txid: string }>;
     waitForSwapSettlement(
         pendingSwap: BoltzSubmarineSwap

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -147,6 +147,29 @@ const dedupeVtxos = (vtxos: VirtualCoin[]): VirtualCoin[] => [
     ).values(),
 ];
 
+const hasNonEmptyString = (value: unknown): value is string =>
+    typeof value === "string" && value.length > 0;
+
+const canRecoverViaBoltz3of3 = (
+    refundableVtxos: VirtualCoin[],
+    swap: BoltzSubmarineSwap
+): boolean => {
+    const hasRequiredSwapMetadata =
+        hasNonEmptyString(swap.id) &&
+        hasNonEmptyString(swap.request.refundPublicKey) &&
+        hasNonEmptyString(swap.response.address) &&
+        hasNonEmptyString(swap.response.claimPublicKey) &&
+        !!swap.response.timeoutBlockHeights;
+
+    if (!hasRequiredSwapMetadata) return false;
+
+    // Pre-CLTV Boltz co-signing only works for normal spendable VTXOs.
+    // Swept/recoverable VTXOs must wait for refundWithoutReceiver.
+    return refundableVtxos.some(
+        (vtxo) => !vtxo.isSpent && !isRecoverable(vtxo)
+    );
+};
+
 const LOCKTIME_THRESHOLD = 500_000_000;
 const isTimestampLocktime = (locktime: number): boolean =>
     locktime >= LOCKTIME_THRESHOLD;
@@ -1017,9 +1040,12 @@ export class ArkadeSwaps {
                 (sum, vtxo) => sum + Number(vtxo.value),
                 0
             );
+            const isRecoverable =
+                locktimeStatus.satisfied ||
+                canRecoverViaBoltz3of3(refundableVtxos, swap);
             return {
                 swap,
-                status: locktimeStatus.satisfied ? "recoverable" : "pre_cltv",
+                status: isRecoverable ? "recoverable" : "pre_cltv",
                 vtxoCount: refundableVtxos.length,
                 amountSats,
                 refundLocktime: timeoutBlockHeights.refund,

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -40,6 +40,7 @@ import type {
     BtcToArkResponse,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
+    SubmarineRefundOutcome,
 } from "./types";
 import {
     BoltzSwapProvider,
@@ -1060,12 +1061,14 @@ export class ArkadeSwaps {
      * Refunds the VHTLC for a failed submarine swap, returning locked funds to the wallet.
      * Uses multi-party signatures (user + Boltz + server) for non-recoverable VTXOs.
      * @param pendingSwap - The submarine swap to refund.
+     * @returns Counts of VTXOs swept vs. deferred. A return value of `{ swept: 0, skipped: N }`
+     *          means the call was a no-op — callers should not treat it as a successful refund.
      * @throws {Error} If preimage hash is unavailable, VHTLC not found, or already spent.
      */
     async refundVHTLC(
         pendingSwap: BoltzSubmarineSwap,
         cachedArkInfo?: ArkInfo
-    ): Promise<void> {
+    ): Promise<SubmarineRefundOutcome> {
         const address = await this.wallet.getAddress();
         if (!address) throw new Error("Failed to get ark address from wallet");
 
@@ -1106,6 +1109,7 @@ export class ArkadeSwaps {
         // Refund every unspent VTXO at the contract address.
         // Throttle between Boltz API calls to avoid 429 rate-limiting.
         let boltzCallCount = 0;
+        let sweptCount = 0;
         let skippedCount = 0;
 
         for (const vtxo of refundableVtxos) {
@@ -1132,6 +1136,7 @@ export class ArkadeSwaps {
                     arkInfo,
                     isRecoverableVtxo
                 );
+                sweptCount++;
                 continue;
             }
 
@@ -1174,6 +1179,7 @@ export class ArkadeSwaps {
                     )
                 );
                 boltzCallCount++;
+                sweptCount++;
             } catch (error) {
                 // Only fall back for Boltz-side rejections (e.g. outpoint
                 // mismatch after an Ark round). Re-throw anything else.
@@ -1215,6 +1221,7 @@ export class ArkadeSwaps {
                     arkInfo,
                     false
                 );
+                sweptCount++;
             }
         }
 
@@ -1232,6 +1239,8 @@ export class ArkadeSwaps {
                 { refundable: true, refunded: fullyRefunded }
             );
         }
+
+        return { swept: sweptCount, skipped: skippedCount };
     }
 
     /**
@@ -1431,8 +1440,8 @@ export class ArkadeSwaps {
     async recoverSubmarineFunds(
         swap: BoltzSubmarineSwap,
         arkInfo?: ArkInfo
-    ): Promise<void> {
-        await this.refundVHTLC(swap, arkInfo);
+    ): Promise<SubmarineRefundOutcome> {
+        return this.refundVHTLC(swap, arkInfo);
     }
 
     /**
@@ -1458,18 +1467,24 @@ export class ArkadeSwaps {
             return swaps.map((swap) => ({
                 swapId: swap.id,
                 recovered: false,
+                skipped: false,
                 error,
             }));
         }
 
         for (const swap of swaps) {
             try {
-                await this.recoverSubmarineFunds(swap, arkInfo);
-                results.push({ swapId: swap.id, recovered: true });
+                const outcome = await this.recoverSubmarineFunds(swap, arkInfo);
+                results.push({
+                    swapId: swap.id,
+                    recovered: outcome.swept > 0,
+                    skipped: outcome.skipped > 0,
+                });
             } catch (err) {
                 results.push({
                     swapId: swap.id,
                     recovered: false,
+                    skipped: false,
                     error: err instanceof Error ? err.message : String(err),
                 });
             }
@@ -2941,12 +2956,16 @@ export interface IArkadeSwaps extends AsyncDisposable {
         args: CreateLightningInvoiceRequest
     ): Promise<BoltzReverseSwap>;
     claimVHTLC(pendingSwap: BoltzReverseSwap): Promise<void>;
-    refundVHTLC(pendingSwap: BoltzSubmarineSwap): Promise<void>;
+    refundVHTLC(
+        pendingSwap: BoltzSubmarineSwap
+    ): Promise<SubmarineRefundOutcome>;
     inspectSubmarineRecovery(
         swap: BoltzSubmarineSwap
     ): Promise<SubmarineRecoveryInfo>;
     scanRecoverableSubmarineSwaps(): Promise<SubmarineRecoveryInfo[]>;
-    recoverSubmarineFunds(swap: BoltzSubmarineSwap): Promise<void>;
+    recoverSubmarineFunds(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRefundOutcome>;
     recoverAllSubmarineFunds(
         swaps: BoltzSubmarineSwap[]
     ): Promise<SubmarineRecoveryResult[]>;

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -98,6 +98,7 @@ import {
     createVHTLCScript,
     joinBatch,
     refundVHTLCwithOffchainTx,
+    type VhtlcTimeouts,
 } from "./utils/vhtlc";
 
 type SubmarineVHTLCDiagnostic = {
@@ -110,7 +111,11 @@ type SubmarineVHTLCContext = {
     vhtlcScript: VHTLC.Script;
     vhtlcAddress: string;
     vhtlcPkScriptHex: string;
-    timeoutBlockHeights: NonNullable<
+    /**
+     * VHTLC timeout fields from the Boltz response. `refund` is an absolute
+     * Unix timestamp (CLTV); the unilateral fields are BIP68 relative delays.
+     */
+    vhtlcTimeouts: NonNullable<
         BoltzSubmarineSwap["response"]["timeoutBlockHeights"]
     >;
     ourXOnlyPublicKey: Uint8Array;
@@ -132,14 +137,6 @@ type SubmarineScanPrepared =
           swap: BoltzSubmarineSwap;
           error: string;
       };
-
-type RefundLocktimeStatus = {
-    satisfied: boolean;
-    currentBlockHeight?: number;
-    currentTimestamp?: number;
-    referenceLabel: "currentBlockHeight" | "currentTimestamp";
-    referenceValue: number;
-};
 
 const dedupeVtxos = (vtxos: VirtualCoin[]): VirtualCoin[] => [
     ...new Map(
@@ -170,9 +167,13 @@ const canRecoverViaBoltz3of3 = (
     );
 };
 
-const LOCKTIME_THRESHOLD = 500_000_000;
-const isTimestampLocktime = (locktime: number): boolean =>
-    locktime >= LOCKTIME_THRESHOLD;
+/**
+ * Boltz Ark VHTLCs encode `refund` as an absolute Unix timestamp (CLTV with
+ * timestamp semantics). Compare against wall-clock seconds; never against
+ * chain tip height.
+ */
+const isSubmarineRefundLocktimeReached = (refundTimestamp: number): boolean =>
+    Math.floor(Date.now() / 1000) >= refundTimestamp;
 
 // Retry policy for fetching the lockup VTXO when claiming a swap: the indexer
 // may lag behind the on-chain lockup tx, so retry a few times before giving up.
@@ -537,9 +538,12 @@ export class ArkadeSwaps {
                 `Swap ${pendingSwap.id}: preimage is required to claim VHTLC`
             );
 
-        const { refundPublicKey, lockupAddress, timeoutBlockHeights } =
-            pendingSwap.response;
-        if (!refundPublicKey || !lockupAddress || !timeoutBlockHeights)
+        const {
+            refundPublicKey,
+            lockupAddress,
+            timeoutBlockHeights: vhtlcTimeouts,
+        } = pendingSwap.response;
+        if (!refundPublicKey || !lockupAddress || !vhtlcTimeouts)
             throw new Error(
                 `Swap ${pendingSwap.id}: incomplete reverse swap response`
             );
@@ -573,7 +577,7 @@ export class ArkadeSwaps {
             receiverPubkey: hex.encode(receiverXOnly),
             senderPubkey: hex.encode(senderXOnly),
             serverPubkey: hex.encode(serverXOnly),
-            timeoutBlockHeights,
+            timeoutBlockHeights: vhtlcTimeouts,
         });
 
         if (!vhtlcScript.claimScript)
@@ -892,8 +896,9 @@ export class ArkadeSwaps {
             swap.id
         );
 
-        const { claimPublicKey, timeoutBlockHeights } = swap.response;
-        if (!claimPublicKey || !timeoutBlockHeights)
+        const { claimPublicKey, timeoutBlockHeights: vhtlcTimeouts } =
+            swap.response;
+        if (!claimPublicKey || !vhtlcTimeouts)
             throw new Error(
                 `Swap ${swap.id}: incomplete submarine swap response`
             );
@@ -910,7 +915,7 @@ export class ArkadeSwaps {
             receiverPubkey: hex.encode(boltzXOnlyPublicKey),
             senderPubkey: hex.encode(ourXOnlyPublicKey),
             serverPubkey: hex.encode(serverXOnlyPublicKey),
-            timeoutBlockHeights,
+            timeoutBlockHeights: vhtlcTimeouts,
         });
 
         if (!vhtlcScript.claimScript)
@@ -934,7 +939,7 @@ export class ArkadeSwaps {
             vhtlcScript,
             vhtlcAddress,
             vhtlcPkScriptHex,
-            timeoutBlockHeights,
+            vhtlcTimeouts,
             ourXOnlyPublicKey,
             serverXOnlyPublicKey,
             boltzXOnlyPublicKey,
@@ -997,59 +1002,31 @@ export class ArkadeSwaps {
         };
     }
 
-    private async getRefundLocktimeStatus(
-        refundLocktime: number,
-        currentBlockHeight?: number
-    ): Promise<RefundLocktimeStatus> {
-        if (isTimestampLocktime(refundLocktime)) {
-            const currentTimestamp = Math.floor(Date.now() / 1000);
-            return {
-                satisfied: currentTimestamp >= refundLocktime,
-                currentTimestamp,
-                referenceLabel: "currentTimestamp",
-                referenceValue: currentTimestamp,
-            };
-        }
-
-        const height =
-            currentBlockHeight ?? (await this.swapProvider.getChainHeight());
-        return {
-            satisfied: height >= refundLocktime,
-            currentBlockHeight: height,
-            referenceLabel: "currentBlockHeight",
-            referenceValue: height,
-        };
-    }
-
-    private async submarineRecoveryInfoFromLookup(
+    private submarineRecoveryInfoFromLookup(
         swap: BoltzSubmarineSwap,
         lookup: Pick<
             SubmarineVHTLCLookup,
-            "timeoutBlockHeights" | "refundableVtxos" | "diagnostic"
-        >,
-        currentBlockHeight?: number
-    ): Promise<SubmarineRecoveryInfo> {
-        const { refundableVtxos, diagnostic, timeoutBlockHeights } = lookup;
+            "vhtlcTimeouts" | "refundableVtxos" | "diagnostic"
+        >
+    ): SubmarineRecoveryInfo {
+        const { refundableVtxos, diagnostic, vhtlcTimeouts } = lookup;
 
         if (refundableVtxos.length > 0) {
-            const locktimeStatus = await this.getRefundLocktimeStatus(
-                timeoutBlockHeights.refund,
-                currentBlockHeight
+            const cltvSatisfied = isSubmarineRefundLocktimeReached(
+                vhtlcTimeouts.refund
             );
             const amountSats = refundableVtxos.reduce(
                 (sum, vtxo) => sum + Number(vtxo.value),
                 0
             );
             const isRecoverable =
-                locktimeStatus.satisfied ||
-                canRecoverViaBoltz3of3(refundableVtxos, swap);
+                cltvSatisfied || canRecoverViaBoltz3of3(refundableVtxos, swap);
             return {
                 swap,
                 status: isRecoverable ? "recoverable" : "pre_cltv",
                 vtxoCount: refundableVtxos.length,
                 amountSats,
-                refundLocktime: timeoutBlockHeights.refund,
-                currentBlockHeight: locktimeStatus.currentBlockHeight,
+                refundLocktime: vhtlcTimeouts.refund,
             };
         }
 
@@ -1061,7 +1038,7 @@ export class ArkadeSwaps {
                 status: "none",
                 vtxoCount: 0,
                 amountSats: 0,
-                refundLocktime: timeoutBlockHeights.refund,
+                refundLocktime: vhtlcTimeouts.refund,
             };
         }
         if (diagnostic.allSpent) {
@@ -1070,7 +1047,7 @@ export class ArkadeSwaps {
                 status: "already_spent",
                 vtxoCount: 0,
                 amountSats: 0,
-                refundLocktime: timeoutBlockHeights.refund,
+                refundLocktime: vhtlcTimeouts.refund,
             };
         }
         // VTXOs exist but none refundable — preconfirmed-only state.
@@ -1079,7 +1056,7 @@ export class ArkadeSwaps {
             status: "none",
             vtxoCount: 0,
             amountSats: 0,
-            refundLocktime: timeoutBlockHeights.refund,
+            refundLocktime: vhtlcTimeouts.refund,
         };
     }
 
@@ -1101,7 +1078,7 @@ export class ArkadeSwaps {
         const {
             arkInfo,
             vhtlcScript,
-            timeoutBlockHeights,
+            vhtlcTimeouts,
             ourXOnlyPublicKey,
             serverXOnlyPublicKey,
             boltzXOnlyPublicKey,
@@ -1127,10 +1104,9 @@ export class ArkadeSwaps {
 
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
-        const locktimeStatus = await this.getRefundLocktimeStatus(
-            timeoutBlockHeights.refund
+        const cltvSatisfied = isSubmarineRefundLocktimeReached(
+            vhtlcTimeouts.refund
         );
-        const cltvSatisfied = locktimeStatus.satisfied;
 
         // Refund every unspent VTXO at the contract address.
         // Throttle between Boltz API calls to avoid 429 rate-limiting.
@@ -1172,8 +1148,8 @@ export class ArkadeSwaps {
                 logger.error(
                     `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
-                        `(refundLocktime=${timeoutBlockHeights.refund}, ` +
-                        `${locktimeStatus.referenceLabel}=${locktimeStatus.referenceValue}). ` +
+                        `(refundLocktime=${vhtlcTimeouts.refund}, ` +
+                        `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
                         `Refund will be retried after locktime.`
                 );
                 skippedCount++;
@@ -1213,18 +1189,14 @@ export class ArkadeSwaps {
                     throw error;
                 }
 
-                // Re-check the locktime reference — it may have advanced while
+                // Re-check the locktime — wall clock may have advanced while
                 // talking to Boltz.
-                const updatedLocktimeStatus =
-                    await this.getRefundLocktimeStatus(
-                        timeoutBlockHeights.refund
-                    );
-                if (!updatedLocktimeStatus.satisfied) {
+                if (!isSubmarineRefundLocktimeReached(vhtlcTimeouts.refund)) {
                     logger.error(
                         `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
-                            `(${updatedLocktimeStatus.referenceLabel}=${updatedLocktimeStatus.referenceValue}, ` +
-                            `locktime=${timeoutBlockHeights.refund}). ` +
+                            `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
+                            `locktime=${vhtlcTimeouts.refund}). ` +
                             `Refund will be retried after locktime.`
                     );
                     skippedCount++;
@@ -1413,45 +1385,28 @@ export class ArkadeSwaps {
             }
         }
 
-        const hasBlockBasedRefundableVtxos = valid.some(({ context }) => {
-            return (
-                !isTimestampLocktime(context.timeoutBlockHeights.refund) &&
-                (refundableByScript.get(context.vhtlcPkScriptHex.toLowerCase())
-                    ?.length ?? 0) > 0
-            );
+        return prepared.map((item) => {
+            if ("error" in item) {
+                return {
+                    swap: item.swap,
+                    status: "invalid_swap" as const,
+                    vtxoCount: 0,
+                    amountSats: 0,
+                    refundLocktime:
+                        item.swap.response.timeoutBlockHeights?.refund,
+                    error: item.error,
+                };
+            }
+
+            const refundableVtxos =
+                refundableByScript.get(
+                    item.context.vhtlcPkScriptHex.toLowerCase()
+                ) ?? [];
+            return this.submarineRecoveryInfoFromLookup(item.swap, {
+                ...item.context,
+                refundableVtxos,
+            });
         });
-        const currentBlockHeight = hasBlockBasedRefundableVtxos
-            ? await this.swapProvider.getChainHeight()
-            : undefined;
-
-        return Promise.all(
-            prepared.map((item) => {
-                if ("error" in item) {
-                    return Promise.resolve({
-                        swap: item.swap,
-                        status: "invalid_swap" as const,
-                        vtxoCount: 0,
-                        amountSats: 0,
-                        refundLocktime:
-                            item.swap.response.timeoutBlockHeights?.refund,
-                        error: item.error,
-                    });
-                }
-
-                const refundableVtxos =
-                    refundableByScript.get(
-                        item.context.vhtlcPkScriptHex.toLowerCase()
-                    ) ?? [];
-                return this.submarineRecoveryInfoFromLookup(
-                    item.swap,
-                    {
-                        ...item.context,
-                        refundableVtxos,
-                    },
-                    currentBlockHeight
-                );
-            })
-        );
     }
 
     /**
@@ -2513,7 +2468,7 @@ export class ArkadeSwaps {
             normalizeToXOnlyKey(arkInfo.signerPubkey, "server")
         );
 
-        const timeoutBlockHeights =
+        const vhtlcTimeouts =
             to === "ARK"
                 ? swap.response.claimDetails.timeouts!
                 : swap.response.lockupDetails.timeouts!;
@@ -2524,7 +2479,7 @@ export class ArkadeSwaps {
             receiverPubkey,
             senderPubkey,
             serverPubkey,
-            timeoutBlockHeights,
+            timeoutBlockHeights: vhtlcTimeouts,
         });
 
         if (lockupAddress !== vhtlcAddress) {
@@ -2587,12 +2542,7 @@ export class ArkadeSwaps {
         receiverPubkey: string;
         senderPubkey: string;
         serverPubkey: string;
-        timeoutBlockHeights: {
-            refund: number;
-            unilateralClaim: number;
-            unilateralRefund: number;
-            unilateralRefundWithoutReceiver: number;
-        };
+        timeoutBlockHeights: VhtlcTimeouts;
     }): { vhtlcScript: VHTLC.Script; vhtlcAddress: string } {
         return createVHTLCScript(args);
     }
@@ -3050,12 +3000,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
         receiverPubkey: string;
         senderPubkey: string;
         serverPubkey: string;
-        timeoutBlockHeights: {
-            refund: number;
-            unilateralClaim: number;
-            unilateralRefund: number;
-            unilateralRefundWithoutReceiver: number;
-        };
+        timeoutBlockHeights: VhtlcTimeouts;
     }): { vhtlcScript: VHTLC.Script; vhtlcAddress: string };
     getFees(): Promise<FeesResponse>;
     getFees(from: Chain, to: Chain): Promise<ChainFeesResponse>;

--- a/src/expo/arkade-lightning.ts
+++ b/src/expo/arkade-lightning.ts
@@ -17,6 +17,8 @@ import type {
     BoltzSwap,
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    SubmarineRecoveryInfo,
+    SubmarineRecoveryResult,
 } from "../types";
 import type { GetSwapStatusResponse } from "../boltz-swap-provider";
 import type {
@@ -304,6 +306,26 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
 
     refundVHTLC(pendingSwap: BoltzSubmarineSwap): Promise<void> {
         return this.inner.refundVHTLC(pendingSwap);
+    }
+
+    inspectSubmarineRecovery(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRecoveryInfo> {
+        return this.inner.inspectSubmarineRecovery(swap);
+    }
+
+    scanRecoverableSubmarineSwaps(): Promise<SubmarineRecoveryInfo[]> {
+        return this.inner.scanRecoverableSubmarineSwaps();
+    }
+
+    recoverSubmarineFunds(swap: BoltzSubmarineSwap): Promise<void> {
+        return this.inner.recoverSubmarineFunds(swap);
+    }
+
+    recoverAllSubmarineFunds(
+        swaps: BoltzSubmarineSwap[]
+    ): Promise<SubmarineRecoveryResult[]> {
+        return this.inner.recoverAllSubmarineFunds(swaps);
     }
 
     waitAndClaim(pendingSwap: BoltzReverseSwap): Promise<{ txid: string }> {

--- a/src/expo/arkade-lightning.ts
+++ b/src/expo/arkade-lightning.ts
@@ -19,6 +19,7 @@ import type {
     SendLightningPaymentResponse,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
+    SubmarineRefundOutcome,
 } from "../types";
 import type { GetSwapStatusResponse } from "../boltz-swap-provider";
 import type {
@@ -304,7 +305,9 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.claimVHTLC(pendingSwap);
     }
 
-    refundVHTLC(pendingSwap: BoltzSubmarineSwap): Promise<void> {
+    refundVHTLC(
+        pendingSwap: BoltzSubmarineSwap
+    ): Promise<SubmarineRefundOutcome> {
         return this.inner.refundVHTLC(pendingSwap);
     }
 
@@ -318,7 +321,9 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.scanRecoverableSubmarineSwaps();
     }
 
-    recoverSubmarineFunds(swap: BoltzSubmarineSwap): Promise<void> {
+    recoverSubmarineFunds(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRefundOutcome> {
         return this.inner.recoverSubmarineFunds(swap);
     }
 

--- a/src/expo/arkade-lightning.ts
+++ b/src/expo/arkade-lightning.ts
@@ -29,6 +29,7 @@ import type {
 import { SWAP_POLL_TASK_TYPE } from "./swapsPollProcessor";
 import type { ArkInfo, ArkTxInput, Identity, VHTLC } from "@arkade-os/sdk";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
+import type { VhtlcTimeouts } from "../utils/vhtlc";
 
 function getRandomId(): string {
     return Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -458,12 +459,7 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         receiverPubkey: string;
         senderPubkey: string;
         serverPubkey: string;
-        timeoutBlockHeights: {
-            refund: number;
-            unilateralClaim: number;
-            unilateralRefund: number;
-            unilateralRefundWithoutReceiver: number;
-        };
+        timeoutBlockHeights: VhtlcTimeouts;
     }): { vhtlcScript: VHTLC.Script; vhtlcAddress: string } {
         return this.inner.createVHTLCScript(params);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,9 @@ export type {
     Network,
     Chain,
     Vtxo,
+    SubmarineRecoveryStatus,
+    SubmarineRecoveryInfo,
+    SubmarineRecoveryResult,
 } from "./types";
 export type {
     SwapManagerConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export type {
     SubmarineRecoveryStatus,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
+    SubmarineRefundOutcome,
 } from "./types";
 export type {
     SwapManagerConfig,

--- a/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -28,6 +28,8 @@ import {
     BoltzSubmarineSwap,
     type SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    type SubmarineRecoveryInfo,
+    type SubmarineRecoveryResult,
 } from "../types";
 import {
     ArkProvider,
@@ -108,6 +110,43 @@ export type RequestRefundVhtlc = RequestEnvelope & {
 };
 export type ResponseRefundVhtlc = ResponseEnvelope & {
     type: "VHTLC_REFUNDED";
+};
+
+// Recovery envelopes carry BoltzSubmarineSwap / SubmarineRecoveryInfo /
+// SubmarineRecoveryResult payloads — all plain JSON-serializable shapes,
+// so they survive the postMessage structured clone unchanged.
+export type RequestInspectSubmarineRecovery = RequestEnvelope & {
+    type: "INSPECT_SUBMARINE_RECOVERY";
+    payload: BoltzSubmarineSwap;
+};
+export type ResponseInspectSubmarineRecovery = ResponseEnvelope & {
+    type: "SUBMARINE_RECOVERY_INSPECTED";
+    payload: SubmarineRecoveryInfo;
+};
+
+export type RequestScanRecoverableSubmarineSwaps = RequestEnvelope & {
+    type: "SCAN_RECOVERABLE_SUBMARINE_SWAPS";
+};
+export type ResponseScanRecoverableSubmarineSwaps = ResponseEnvelope & {
+    type: "RECOVERABLE_SUBMARINE_SWAPS_SCANNED";
+    payload: SubmarineRecoveryInfo[];
+};
+
+export type RequestRecoverSubmarineFunds = RequestEnvelope & {
+    type: "RECOVER_SUBMARINE_FUNDS";
+    payload: BoltzSubmarineSwap;
+};
+export type ResponseRecoverSubmarineFunds = ResponseEnvelope & {
+    type: "SUBMARINE_FUNDS_RECOVERED";
+};
+
+export type RequestRecoverAllSubmarineFunds = RequestEnvelope & {
+    type: "RECOVER_ALL_SUBMARINE_FUNDS";
+    payload: BoltzSubmarineSwap[];
+};
+export type ResponseRecoverAllSubmarineFunds = ResponseEnvelope & {
+    type: "ALL_SUBMARINE_FUNDS_RECOVERED";
+    payload: SubmarineRecoveryResult[];
 };
 
 export type RequestWaitAndClaim = RequestEnvelope & {
@@ -440,6 +479,10 @@ export type ArkadeSwapsUpdaterRequest =
     | RequestCreateReverseSwap
     | RequestClaimVhtlc
     | RequestRefundVhtlc
+    | RequestInspectSubmarineRecovery
+    | RequestScanRecoverableSubmarineSwaps
+    | RequestRecoverSubmarineFunds
+    | RequestRecoverAllSubmarineFunds
     | RequestWaitAndClaim
     | RequestWaitForSwapSettlement
     | RequestRestoreSwaps
@@ -483,6 +526,10 @@ export type ArkadeSwapsUpdaterResponse =
     | ResponseCreateReverseSwap
     | ResponseClaimVhtlc
     | ResponseRefundVhtlc
+    | ResponseInspectSubmarineRecovery
+    | ResponseScanRecoverableSubmarineSwaps
+    | ResponseRecoverSubmarineFunds
+    | ResponseRecoverAllSubmarineFunds
     | ResponseWaitAndClaim
     | ResponseWaitForSwapSettlement
     | ResponseRestoreSwaps
@@ -524,6 +571,10 @@ export const LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES: ReadonlySet<
     "SEND_LIGHTNING_PAYMENT",
     "CLAIM_VHTLC",
     "REFUND_VHTLC",
+    "INSPECT_SUBMARINE_RECOVERY",
+    "SCAN_RECOVERABLE_SUBMARINE_SWAPS",
+    "RECOVER_SUBMARINE_FUNDS",
+    "RECOVER_ALL_SUBMARINE_FUNDS",
     "WAIT_AND_CLAIM",
     "WAIT_FOR_SWAP_SETTLEMENT",
     "RESTORE_SWAPS",
@@ -744,6 +795,45 @@ export class ArkadeSwapsMessageHandler
                 case "REFUND_VHTLC":
                     await this.handler.refundVHTLC(message.payload);
                     return this.tagged({ id, type: "VHTLC_REFUNDED" });
+
+                case "INSPECT_SUBMARINE_RECOVERY": {
+                    const info = await this.handler.inspectSubmarineRecovery(
+                        message.payload
+                    );
+                    return this.tagged({
+                        id,
+                        type: "SUBMARINE_RECOVERY_INSPECTED",
+                        payload: info,
+                    });
+                }
+
+                case "SCAN_RECOVERABLE_SUBMARINE_SWAPS": {
+                    const infos =
+                        await this.handler.scanRecoverableSubmarineSwaps();
+                    return this.tagged({
+                        id,
+                        type: "RECOVERABLE_SUBMARINE_SWAPS_SCANNED",
+                        payload: infos,
+                    });
+                }
+
+                case "RECOVER_SUBMARINE_FUNDS":
+                    await this.handler.recoverSubmarineFunds(message.payload);
+                    return this.tagged({
+                        id,
+                        type: "SUBMARINE_FUNDS_RECOVERED",
+                    });
+
+                case "RECOVER_ALL_SUBMARINE_FUNDS": {
+                    const results = await this.handler.recoverAllSubmarineFunds(
+                        message.payload
+                    );
+                    return this.tagged({
+                        id,
+                        type: "ALL_SUBMARINE_FUNDS_RECOVERED",
+                        payload: results,
+                    });
+                }
 
                 case "WAIT_AND_CLAIM": {
                     const res = await this.handler.waitAndClaim(

--- a/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -30,6 +30,7 @@ import {
     SendLightningPaymentResponse,
     type SubmarineRecoveryInfo,
     type SubmarineRecoveryResult,
+    type SubmarineRefundOutcome,
 } from "../types";
 import {
     ArkProvider,
@@ -110,6 +111,7 @@ export type RequestRefundVhtlc = RequestEnvelope & {
 };
 export type ResponseRefundVhtlc = ResponseEnvelope & {
     type: "VHTLC_REFUNDED";
+    payload: SubmarineRefundOutcome;
 };
 
 // Recovery envelopes carry BoltzSubmarineSwap / SubmarineRecoveryInfo /
@@ -138,6 +140,7 @@ export type RequestRecoverSubmarineFunds = RequestEnvelope & {
 };
 export type ResponseRecoverSubmarineFunds = ResponseEnvelope & {
     type: "SUBMARINE_FUNDS_RECOVERED";
+    payload: SubmarineRefundOutcome;
 };
 
 export type RequestRecoverAllSubmarineFunds = RequestEnvelope & {
@@ -792,9 +795,16 @@ export class ArkadeSwapsMessageHandler
                     await this.handler.claimVHTLC(message.payload);
                     return this.tagged({ id, type: "VHTLC_CLAIMED" });
 
-                case "REFUND_VHTLC":
-                    await this.handler.refundVHTLC(message.payload);
-                    return this.tagged({ id, type: "VHTLC_REFUNDED" });
+                case "REFUND_VHTLC": {
+                    const outcome = await this.handler.refundVHTLC(
+                        message.payload
+                    );
+                    return this.tagged({
+                        id,
+                        type: "VHTLC_REFUNDED",
+                        payload: outcome,
+                    });
+                }
 
                 case "INSPECT_SUBMARINE_RECOVERY": {
                     const info = await this.handler.inspectSubmarineRecovery(
@@ -817,12 +827,16 @@ export class ArkadeSwapsMessageHandler
                     });
                 }
 
-                case "RECOVER_SUBMARINE_FUNDS":
-                    await this.handler.recoverSubmarineFunds(message.payload);
+                case "RECOVER_SUBMARINE_FUNDS": {
+                    const outcome = await this.handler.recoverSubmarineFunds(
+                        message.payload
+                    );
                     return this.tagged({
                         id,
                         type: "SUBMARINE_FUNDS_RECOVERED",
+                        payload: outcome,
                     });
+                }
 
                 case "RECOVER_ALL_SUBMARINE_FUNDS": {
                     const results = await this.handler.recoverAllSubmarineFunds(

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -66,6 +66,7 @@ import {
 } from "@arkade-os/sdk";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import { IArkadeSwaps } from "../arkade-swaps";
+import type { VhtlcTimeouts } from "../utils/vhtlc";
 import { IndexedDbSwapRepository } from "../repositories/IndexedDb/swap-repository";
 import {
     enrichReverseSwapPreimage as _enrichReverseSwapPreimage,
@@ -852,12 +853,7 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         receiverPubkey: string;
         senderPubkey: string;
         serverPubkey: string;
-        timeoutBlockHeights: {
-            refund: number;
-            unilateralClaim: number;
-            unilateralRefund: number;
-            unilateralRefundWithoutReceiver: number;
-        };
+        timeoutBlockHeights: VhtlcTimeouts;
     }): { vhtlcScript: VHTLC.Script; vhtlcAddress: string } {
         throw new Error(
             "createVHTLCScript is not supported via service worker"

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -15,6 +15,8 @@ import {
     BoltzSubmarineSwap,
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    SubmarineRecoveryInfo,
+    SubmarineRecoveryResult,
 } from "../types";
 import { SwapRepository } from "../repositories/swap-repository";
 import {
@@ -47,6 +49,9 @@ import type {
     ResponseWaitAndClaimChain,
     ResponseWaitAndClaim,
     ResponseWaitForSwapSettlement,
+    ResponseInspectSubmarineRecovery,
+    ResponseScanRecoverableSubmarineSwaps,
+    ResponseRecoverAllSubmarineFunds,
 } from "./arkade-swaps-message-handler";
 import {
     MESSAGE_BUS_NOT_INITIALIZED,
@@ -530,6 +535,48 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
             type: "REFUND_VHTLC",
             payload: pendingSwap,
         });
+    }
+
+    async inspectSubmarineRecovery(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRecoveryInfo> {
+        const res = await this.sendMessage({
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "INSPECT_SUBMARINE_RECOVERY",
+            payload: swap,
+        });
+        return (res as ResponseInspectSubmarineRecovery).payload;
+    }
+
+    async scanRecoverableSubmarineSwaps(): Promise<SubmarineRecoveryInfo[]> {
+        const res = await this.sendMessage({
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "SCAN_RECOVERABLE_SUBMARINE_SWAPS",
+        });
+        return (res as ResponseScanRecoverableSubmarineSwaps).payload;
+    }
+
+    async recoverSubmarineFunds(swap: BoltzSubmarineSwap): Promise<void> {
+        await this.sendMessage({
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "RECOVER_SUBMARINE_FUNDS",
+            payload: swap,
+        });
+    }
+
+    async recoverAllSubmarineFunds(
+        swaps: BoltzSubmarineSwap[]
+    ): Promise<SubmarineRecoveryResult[]> {
+        const res = await this.sendMessage({
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "RECOVER_ALL_SUBMARINE_FUNDS",
+            payload: swaps,
+        });
+        return (res as ResponseRecoverAllSubmarineFunds).payload;
     }
 
     async waitAndClaim(

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -17,6 +17,7 @@ import {
     SendLightningPaymentResponse,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
+    SubmarineRefundOutcome,
 } from "../types";
 import { SwapRepository } from "../repositories/swap-repository";
 import {
@@ -52,6 +53,8 @@ import type {
     ResponseInspectSubmarineRecovery,
     ResponseScanRecoverableSubmarineSwaps,
     ResponseRecoverAllSubmarineFunds,
+    ResponseRefundVhtlc,
+    ResponseRecoverSubmarineFunds,
 } from "./arkade-swaps-message-handler";
 import {
     MESSAGE_BUS_NOT_INITIALIZED,
@@ -528,13 +531,16 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         });
     }
 
-    async refundVHTLC(pendingSwap: BoltzSubmarineSwap): Promise<void> {
-        await this.sendMessage({
+    async refundVHTLC(
+        pendingSwap: BoltzSubmarineSwap
+    ): Promise<SubmarineRefundOutcome> {
+        const res = await this.sendMessage({
             id: getRandomId(),
             tag: this.messageTag,
             type: "REFUND_VHTLC",
             payload: pendingSwap,
         });
+        return (res as ResponseRefundVhtlc).payload;
     }
 
     async inspectSubmarineRecovery(
@@ -558,13 +564,16 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         return (res as ResponseScanRecoverableSubmarineSwaps).payload;
     }
 
-    async recoverSubmarineFunds(swap: BoltzSubmarineSwap): Promise<void> {
-        await this.sendMessage({
+    async recoverSubmarineFunds(
+        swap: BoltzSubmarineSwap
+    ): Promise<SubmarineRefundOutcome> {
+        const res = await this.sendMessage({
             id: getRandomId(),
             tag: this.messageTag,
             type: "RECOVER_SUBMARINE_FUNDS",
             payload: swap,
         });
+        return (res as ResponseRecoverSubmarineFunds).payload;
     }
 
     async recoverAllSubmarineFunds(

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,10 +181,11 @@ export interface SubmarineRecoveryInfo {
     vtxoCount: number;
     /** Total satoshis across the unspent VTXOs. */
     amountSats: number;
-    /** Refund CLTV block height for the swap, when available. */
+    /**
+     * Absolute Unix-timestamp CLTV from the swap's VHTLC, when available.
+     * Compared against wall-clock seconds for refund readiness.
+     */
     refundLocktime?: number;
-    /** Current chain tip height, when using a block-height locktime. */
-    currentBlockHeight?: number;
     /** Reason populated when `status === "invalid_swap"`. */
     error?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,10 +151,11 @@ export interface BoltzSubmarineSwap {
  * Outcome of inspecting a submarine swap's lockup address for recoverable
  * funds.
  *
- * - `recoverable` — unspent VTXOs exist and the refund CLTV has elapsed,
- *   so they can be swept via the unilateral refund path.
+ * - `recoverable` — unspent VTXOs exist and can be swept now, either because
+ *   the refund CLTV has elapsed or because the Boltz 3-of-3 refund path is
+ *   immediately available.
  * - `pre_cltv` — unspent VTXOs exist but the refund locktime has not
- *   passed yet; the user must wait or rely on Boltz cooperation.
+ *   passed yet and no immediate Boltz 3-of-3 refund path was detected.
  * - `none` — no unspent VTXOs at the address (never funded, fully
  *   pruned, or only preconfirmed-only state).
  * - `already_spent` — the address has VTXOs but every one is spent

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,57 @@ export interface BoltzSubmarineSwap {
     response: CreateSubmarineSwapResponse;
 }
 
+/**
+ * Outcome of inspecting a submarine swap's lockup address for recoverable
+ * funds.
+ *
+ * - `recoverable` — unspent VTXOs exist and the refund CLTV has elapsed,
+ *   so they can be swept via the unilateral refund path.
+ * - `pre_cltv` — unspent VTXOs exist but the refund locktime has not
+ *   passed yet; the user must wait or rely on Boltz cooperation.
+ * - `none` — no unspent VTXOs at the address (never funded, fully
+ *   pruned, or only preconfirmed-only state).
+ * - `already_spent` — the address has VTXOs but every one is spent
+ *   (typical for a healthy completed swap).
+ * - `invalid_swap` — the swap is not a recovery candidate (pending
+ *   status), the swap data is incomplete, or the reconstructed VHTLC
+ *   address doesn't match the one Boltz returned.
+ */
+export type SubmarineRecoveryStatus =
+    | "recoverable"
+    | "pre_cltv"
+    | "none"
+    | "already_spent"
+    | "invalid_swap";
+
+/** Diagnostic snapshot of a submarine swap's recovery state. */
+export interface SubmarineRecoveryInfo {
+    /** The submarine swap this snapshot describes. */
+    swap: BoltzSubmarineSwap;
+    /** Classification of the lockup address state. */
+    status: SubmarineRecoveryStatus;
+    /** Number of unspent VTXOs at the lockup address. */
+    vtxoCount: number;
+    /** Total satoshis across the unspent VTXOs. */
+    amountSats: number;
+    /** Refund CLTV block height for the swap, when available. */
+    refundLocktime?: number;
+    /** Current chain tip height, when using a block-height locktime. */
+    currentBlockHeight?: number;
+    /** Reason populated when `status === "invalid_swap"`. */
+    error?: string;
+}
+
+/** Per-swap outcome of a bulk recovery call. */
+export interface SubmarineRecoveryResult {
+    /** ID of the swap whose VHTLC we attempted to refund. */
+    swapId: string;
+    /** True if `refundVHTLC` returned without throwing. */
+    recovered: boolean;
+    /** Failure message when `recovered === false`. */
+    error?: string;
+}
+
 /** Tracks an in-progress chain swap (ARK ↔ BTC). */
 export interface BoltzChainSwap {
     /** Unique swap ID from Boltz. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,13 +188,31 @@ export interface SubmarineRecoveryInfo {
     error?: string;
 }
 
+/** Outcome of a single `refundVHTLC` call: how many VTXOs were swept vs. deferred. */
+export interface SubmarineRefundOutcome {
+    /** Number of VTXOs successfully refunded (joined a batch or via Boltz co-sign). */
+    swept: number;
+    /**
+     * Number of VTXOs that could not be refunded yet (e.g. recoverable VTXO
+     * pre-CLTV, or Boltz rejected and CLTV still not satisfied). The caller
+     * is expected to retry these later.
+     */
+    skipped: number;
+}
+
 /** Per-swap outcome of a bulk recovery call. */
 export interface SubmarineRecoveryResult {
     /** ID of the swap whose VHTLC we attempted to refund. */
     swapId: string;
-    /** True if `refundVHTLC` returned without throwing. */
+    /** True only when at least one VTXO was actually swept by `refundVHTLC`. */
     recovered: boolean;
-    /** Failure message when `recovered === false`. */
+    /**
+     * True when `refundVHTLC` returned without throwing but at least one
+     * VTXO was deferred — distinguishes a real sweep from a no-op skip
+     * path. Always false when `error` is set (the error supersedes).
+     */
+    skipped: boolean;
+    /** Failure message when `refundVHTLC` threw. */
     error?: string;
 }
 

--- a/src/utils/scripts.ts
+++ b/src/utils/scripts.ts
@@ -4,6 +4,26 @@ import { VHTLC } from "@arkade-os/sdk";
 import { ripemd160 } from "@noble/hashes/legacy.js";
 
 /**
+ * Boltz-Ark VHTLC timeouts. See {@link ./vhtlc.ts#VhtlcTimeouts} for the
+ * canonical definition; this duplicate exists only to keep the legacy
+ * `createVHTLCScript` exported from this module type-aligned. `refund` is an
+ * absolute Unix timestamp; the unilateral fields are BIP68 relative delays
+ * (seconds when ≥ 512).
+ */
+export type VhtlcTimeouts = {
+    refund: number;
+    unilateralClaim: number;
+    unilateralRefund: number;
+    unilateralRefundWithoutReceiver: number;
+};
+
+const toBip68RelativeTimelock = (value: number) =>
+    ({
+        type: value < 512 ? ("blocks" as const) : ("seconds" as const),
+        value: BigInt(value),
+    }) as const;
+
+/**
  * Creates a VHTLC script for the swap.
  * works for submarine swaps and reverse swaps
  * it creates a VHTLC script that can be used to claim or refund the swap
@@ -20,19 +40,14 @@ export function createVHTLCScript({
     receiverPubkey,
     senderPubkey,
     serverPubkey,
-    timeoutBlockHeights,
+    timeoutBlockHeights: vhtlcTimeouts,
 }: {
     network: string;
     preimageHash: Uint8Array;
     receiverPubkey: string;
     senderPubkey: string;
     serverPubkey: string;
-    timeoutBlockHeights: {
-        refund: number;
-        unilateralClaim: number;
-        unilateralRefund: number;
-        unilateralRefundWithoutReceiver: number;
-    };
+    timeoutBlockHeights: VhtlcTimeouts;
 }): { vhtlcScript: VHTLC.Script; vhtlcAddress: string } {
     // validate we are using a x-only receiver public key
     const receiverXOnlyPublicKey = normalizeToXOnlyPublicKey(
@@ -52,28 +67,21 @@ export function createVHTLCScript({
         "server"
     );
 
-    const delayType = (num: number) => (num < 512 ? "blocks" : "seconds");
-
     const vhtlcScript = new VHTLC.Script({
         preimageHash: ripemd160(preimageHash),
         sender: senderXOnlyPublicKey,
         receiver: receiverXOnlyPublicKey,
         server: serverXOnlyPublicKey,
-        refundLocktime: BigInt(timeoutBlockHeights.refund),
-        unilateralClaimDelay: {
-            type: delayType(timeoutBlockHeights.unilateralClaim),
-            value: BigInt(timeoutBlockHeights.unilateralClaim),
-        },
-        unilateralRefundDelay: {
-            type: delayType(timeoutBlockHeights.unilateralRefund),
-            value: BigInt(timeoutBlockHeights.unilateralRefund),
-        },
-        unilateralRefundWithoutReceiverDelay: {
-            type: delayType(
-                timeoutBlockHeights.unilateralRefundWithoutReceiver
-            ),
-            value: BigInt(timeoutBlockHeights.unilateralRefundWithoutReceiver),
-        },
+        refundLocktime: BigInt(vhtlcTimeouts.refund),
+        unilateralClaimDelay: toBip68RelativeTimelock(
+            vhtlcTimeouts.unilateralClaim
+        ),
+        unilateralRefundDelay: toBip68RelativeTimelock(
+            vhtlcTimeouts.unilateralRefund
+        ),
+        unilateralRefundWithoutReceiverDelay: toBip68RelativeTimelock(
+            vhtlcTimeouts.unilateralRefundWithoutReceiver
+        ),
     });
 
     if (!vhtlcScript) throw new Error("Failed to create VHTLC script");

--- a/src/utils/vhtlc.ts
+++ b/src/utils/vhtlc.ts
@@ -27,6 +27,36 @@ import { normalizeToXOnlyKey, verifySignatures } from "./signatures";
 import { TransactionOutput, TransactionInput } from "@scure/btc-signer/psbt.js";
 
 /**
+ * Boltz-Ark VHTLC timeouts. The shape matches Boltz's `timeoutBlockHeights`
+ * API field, but the legacy name is misleading — these are not all block
+ * heights:
+ * - `refund` is an absolute Unix timestamp in seconds (CLTV with timestamp
+ *   semantics, BIP65 threshold ≥ 500_000_000).
+ * - `unilateralClaim`, `unilateralRefund`, `unilateralRefundWithoutReceiver`
+ *   are BIP68 *relative* delays measured from the lockup confirmation. Values
+ *   ≥ 512 are interpreted as seconds (BIP68 type-flag). For Boltz Ark mainnet
+ *   they're always seconds.
+ */
+export type VhtlcTimeouts = {
+    refund: number;
+    unilateralClaim: number;
+    unilateralRefund: number;
+    unilateralRefundWithoutReceiver: number;
+};
+
+/**
+ * Map a BIP68 relative-timelock value to a `{ type, value }` pair.
+ * BIP68 encodes the unit in a type-flag bit; values ≥ 512 are seconds, values
+ * below the threshold are blocks. Boltz Ark always returns seconds in
+ * production, but the helper supports both for completeness.
+ */
+const toBip68RelativeTimelock = (value: number) =>
+    ({
+        type: value < 512 ? ("blocks" as const) : ("seconds" as const),
+        value: BigInt(value),
+    }) as const;
+
+/**
  * Creates a VHTLC script for the swap.
  * Works for submarine, reverse, and chain swaps.
  * It creates a VHTLC script that can be used to claim or refund the swap.
@@ -34,6 +64,9 @@ import { TransactionOutput, TransactionInput } from "@scure/btc-signer/psbt.js";
  * @param args - The parameters for creating the VHTLC script.
  * @param args.preimageHash - The SHA256 digest of the preimage (not the raw preimage or RIPEMD160 hash).
  * The function will apply ripemd160(preimageHash) internally to create the final commitment.
+ * @param args.timeoutBlockHeights - Boltz timeout fields. Despite the legacy
+ *   field name, see {@link VhtlcTimeouts} for the actual semantics — `refund`
+ *   is a Unix timestamp, the unilateral fields are BIP68 relative delays.
  * @returns The created VHTLC script and address.
  */
 export const createVHTLCScript = (args: {
@@ -42,12 +75,7 @@ export const createVHTLCScript = (args: {
     receiverPubkey: string;
     senderPubkey: string;
     serverPubkey: string;
-    timeoutBlockHeights: {
-        refund: number;
-        unilateralClaim: number;
-        unilateralRefund: number;
-        unilateralRefundWithoutReceiver: number;
-    };
+    timeoutBlockHeights: VhtlcTimeouts;
 }): { vhtlcScript: VHTLC.Script; vhtlcAddress: string } => {
     const {
         network,
@@ -55,7 +83,7 @@ export const createVHTLCScript = (args: {
         receiverPubkey,
         senderPubkey,
         serverPubkey,
-        timeoutBlockHeights,
+        timeoutBlockHeights: vhtlcTimeouts,
     } = args;
     // validate we are using a x-only receiver public key
     const receiverXOnlyPublicKey = normalizeToXOnlyKey(
@@ -75,28 +103,21 @@ export const createVHTLCScript = (args: {
         "server"
     );
 
-    const delayType = (num: number) => (num < 512 ? "blocks" : "seconds");
-
     const vhtlcScript = new VHTLC.Script({
         preimageHash: ripemd160(preimageHash),
         sender: senderXOnlyPublicKey,
         receiver: receiverXOnlyPublicKey,
         server: serverXOnlyPublicKey,
-        refundLocktime: BigInt(timeoutBlockHeights.refund),
-        unilateralClaimDelay: {
-            type: delayType(timeoutBlockHeights.unilateralClaim),
-            value: BigInt(timeoutBlockHeights.unilateralClaim),
-        },
-        unilateralRefundDelay: {
-            type: delayType(timeoutBlockHeights.unilateralRefund),
-            value: BigInt(timeoutBlockHeights.unilateralRefund),
-        },
-        unilateralRefundWithoutReceiverDelay: {
-            type: delayType(
-                timeoutBlockHeights.unilateralRefundWithoutReceiver
-            ),
-            value: BigInt(timeoutBlockHeights.unilateralRefundWithoutReceiver),
-        },
+        refundLocktime: BigInt(vhtlcTimeouts.refund),
+        unilateralClaimDelay: toBip68RelativeTimelock(
+            vhtlcTimeouts.unilateralClaim
+        ),
+        unilateralRefundDelay: toBip68RelativeTimelock(
+            vhtlcTimeouts.unilateralRefund
+        ),
+        unilateralRefundWithoutReceiverDelay: toBip68RelativeTimelock(
+            vhtlcTimeouts.unilateralRefundWithoutReceiver
+        ),
     });
 
     if (!vhtlcScript.claimScript)

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -3109,6 +3109,19 @@ describe("ArkadeSwaps", () => {
             expect(info.currentBlockHeight).toBe(5);
         });
 
+        it("returns recoverable pre-CLTV when VTXOs can use Boltz 3-of-3 refund", async () => {
+            mockSelection({
+                spendable: [makeVtxo(lockupTxid, 0, 50000, false, "settled")],
+            });
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("recoverable");
+            expect(info.vtxoCount).toBe(1);
+            expect(info.currentBlockHeight).toBe(5);
+        });
+
         it("uses Unix time instead of chain height for timestamp locktimes", async () => {
             const timestampSwap: BoltzSubmarineSwap = {
                 ...claimedSwap,

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -3447,8 +3447,16 @@ describe("ArkadeSwaps", () => {
                 ]);
 
                 expect(results).toEqual([
-                    { swapId: "claimed-swap-id", recovered: true },
-                    { swapId: "failed-swap-id", recovered: true },
+                    {
+                        swapId: "claimed-swap-id",
+                        recovered: true,
+                        skipped: false,
+                    },
+                    {
+                        swapId: "failed-swap-id",
+                        recovered: true,
+                        skipped: false,
+                    },
                 ]);
                 expect(arkProvider.getInfo).toHaveBeenCalledTimes(1);
             });
@@ -3475,17 +3483,41 @@ describe("ArkadeSwaps", () => {
                 expect(results[0]).toMatchObject({
                     swapId: "claimed-swap-id",
                     recovered: false,
+                    skipped: false,
                 });
                 expect(results[0].error).toMatch(/address mismatch/i);
                 expect(results[1]).toEqual({
                     swapId: "failed-swap-id",
                     recovered: true,
+                    skipped: false,
                 });
             });
 
             it("returns an empty array when given no swaps", async () => {
                 const results = await swaps.recoverAllSubmarineFunds([]);
                 expect(results).toEqual([]);
+            });
+
+            it("flags skipped (not recovered) when refundVHTLC sweeps nothing", async () => {
+                // Pre-CLTV recoverable VTXO → refundVHTLC returns
+                // { swept: 0, skipped: 1 } without throwing. Aggregator must
+                // surface that as recovered:false / skipped:true rather than
+                // misreporting a successful sweep.
+                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+
+                const results = await swaps.recoverAllSubmarineFunds([
+                    failedSwap,
+                ]);
+
+                expect(results).toEqual([
+                    {
+                        swapId: "failed-swap-id",
+                        recovered: false,
+                        skipped: true,
+                    },
+                ]);
+                const joinBatch = vi.mocked((swaps as any).joinBatch);
+                expect(joinBatch).not.toHaveBeenCalled();
             });
         });
     });

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -2978,4 +2978,515 @@ describe("ArkadeSwaps", () => {
             expect(indexerProvider.getVtxos).not.toHaveBeenCalled();
         });
     });
+
+    describe("inspectSubmarineRecovery", () => {
+        const lockupTxid = hex.encode(randomBytes(32));
+
+        const makeVtxo = (
+            txid: string,
+            vout: number,
+            value = 50000,
+            isSpent = false,
+            virtualState: "swept" | "settled" | "preconfirmed" = "swept"
+        ) => ({
+            txid,
+            vout,
+            value,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: virtualState },
+            isSpent,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const claimedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "claimed-swap-id",
+            status: "transaction.claimed",
+        };
+
+        const failedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "failed-swap-id",
+            status: "invoice.failedToPay",
+        };
+
+        const mockSelection = (args: {
+            spendable?: any[];
+            recoverable?: any[];
+            all?: any[];
+        }) => {
+            const spendable = args.spendable ?? [];
+            const recoverable = args.recoverable ?? [];
+            const all = args.all ?? [
+                ...new Map(
+                    [...spendable, ...recoverable].map((vtxo) => [
+                        `${vtxo.txid}:${vtxo.vout}`,
+                        vtxo,
+                    ])
+                ).values(),
+            ];
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.spendableOnly) return { vtxos: spendable } as any;
+                    if (opts?.recoverableOnly)
+                        return { vtxos: recoverable } as any;
+                    return { vtxos: all } as any;
+                }
+            );
+        };
+
+        beforeEach(() => {
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+            vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+
+            vi.spyOn(swaps as any, "createVHTLCScript").mockReturnValue({
+                vhtlcScript: {
+                    claimScript: new Uint8Array([1]),
+                    pkScript: new Uint8Array([2]),
+                    refund: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    refundWithoutReceiver: () =>
+                        [{}, new Uint8Array([4]), 0xc0] as any,
+                    encode: () => [] as any,
+                    options: {
+                        refundLocktime:
+                            claimedSwap.response.timeoutBlockHeights.refund,
+                    },
+                },
+                vhtlcAddress: claimedSwap.response.address,
+            });
+        });
+
+        it("returns recoverable for transaction.claimed plus post-CLTV VTXO", async () => {
+            mockSelection({ recoverable: [makeVtxo(lockupTxid, 0, 75000)] });
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("recoverable");
+            expect(info.swap).toBe(claimedSwap);
+            expect(info.vtxoCount).toBe(1);
+            expect(info.amountSats).toBe(75000);
+            expect(info.refundLocktime).toBe(17);
+            expect(info.currentBlockHeight).toBe(100);
+        });
+
+        it("returns recoverable for failed refundable status plus post-CLTV VTXO", async () => {
+            mockSelection({ recoverable: [makeVtxo(lockupTxid, 0, 30000)] });
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+
+            const info = await swaps.inspectSubmarineRecovery(failedSwap);
+
+            expect(info.status).toBe("recoverable");
+            expect(info.swap.id).toBe("failed-swap-id");
+            expect(info.amountSats).toBe(30000);
+        });
+
+        it("sums amount across multiple unspent VTXOs", async () => {
+            mockSelection({
+                recoverable: [
+                    makeVtxo(lockupTxid, 0, 30000),
+                    makeVtxo(lockupTxid, 1, 20000),
+                ],
+            });
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("recoverable");
+            expect(info.vtxoCount).toBe(2);
+            expect(info.amountSats).toBe(50000);
+        });
+
+        it("returns pre_cltv when unspent VTXOs exist but locktime hasn't passed", async () => {
+            mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("pre_cltv");
+            expect(info.vtxoCount).toBe(1);
+            expect(info.currentBlockHeight).toBe(5);
+        });
+
+        it("uses Unix time instead of chain height for timestamp locktimes", async () => {
+            const timestampSwap: BoltzSubmarineSwap = {
+                ...claimedSwap,
+                response: {
+                    ...claimedSwap.response,
+                    timeoutBlockHeights: {
+                        ...claimedSwap.response.timeoutBlockHeights,
+                        refund: Math.floor(Date.now() / 1000) - 1,
+                    },
+                },
+            };
+            mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
+            const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
+
+            const info = await swaps.inspectSubmarineRecovery(timestampSwap);
+
+            expect(info.status).toBe("recoverable");
+            expect(info.currentBlockHeight).toBeUndefined();
+            expect(chainHeightSpy).not.toHaveBeenCalled();
+        });
+
+        it("returns none when the address has no VTXOs at all", async () => {
+            mockSelection({});
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("none");
+            expect(info.vtxoCount).toBe(0);
+            expect(info.amountSats).toBe(0);
+        });
+
+        it("returns already_spent when every VTXO at the address is spent", async () => {
+            const spent = makeVtxo(lockupTxid, 0, 50000, true);
+            mockSelection({ all: [spent] });
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("already_spent");
+            expect(info.vtxoCount).toBe(0);
+        });
+
+        it("returns invalid_swap for pending statuses without hitting the indexer", async () => {
+            const pendingSwap: BoltzSubmarineSwap = {
+                ...mockSubmarineSwap,
+                status: "transaction.mempool",
+            };
+
+            const info = await swaps.inspectSubmarineRecovery(pendingSwap);
+
+            expect(info.status).toBe("invalid_swap");
+            expect(info.error).toMatch(/transaction\.mempool/);
+            expect(indexerProvider.getVtxos).not.toHaveBeenCalled();
+            expect(arkProvider.getInfo).not.toHaveBeenCalled();
+        });
+
+        it("returns invalid_swap when VHTLC address can't be reconstructed", async () => {
+            vi.spyOn(swaps as any, "createVHTLCScript").mockReturnValue({
+                vhtlcScript: { claimScript: new Uint8Array([1]) },
+                vhtlcAddress: "ark1-wrong-address",
+            });
+
+            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(info.status).toBe("invalid_swap");
+            expect(info.error).toMatch(/address mismatch/i);
+            expect(info.vtxoCount).toBe(0);
+        });
+
+        it("does not mutate the repository", async () => {
+            mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+
+            await swaps.inspectSubmarineRecovery(claimedSwap);
+
+            expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+            expect(mockSwapRepository.deleteSwap).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("scanRecoverableSubmarineSwaps", () => {
+        const lockupTxid = hex.encode(randomBytes(32));
+        const makeVtxo = (
+            txid: string,
+            vout: number,
+            script: string,
+            value = 50000
+        ) => ({
+            txid,
+            vout,
+            value,
+            script,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "swept" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const claimedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "claimed-swap-id",
+            status: "transaction.claimed",
+        };
+        const failedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "failed-swap-id",
+            status: "invoice.failedToPay",
+        };
+        const pendingSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "pending-swap-id",
+            status: "transaction.mempool",
+        };
+
+        beforeEach(() => {
+            // Repo is asked only for type:"submarine"; non-submarine swaps
+            // never reach scan, so test harness only needs to return
+            // submarine candidates plus a pending one to exercise filtering.
+            vi.mocked(mockSwapRepository.getAllSwaps).mockImplementation(
+                async (filter: any) => {
+                    expect(filter).toEqual({ type: "submarine" });
+                    return [claimedSwap, failedSwap, pendingSwap];
+                }
+            );
+
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+
+            // The two valid candidates reconstruct to distinct scripts so the
+            // batched indexer response can be mapped back per swap.
+            let scriptByte = 1;
+            vi.spyOn(swaps as any, "createVHTLCScript").mockImplementation(
+                () => {
+                    const pkScript = new Uint8Array([scriptByte++]);
+                    return {
+                        vhtlcScript: {
+                            claimScript: new Uint8Array([1]),
+                            pkScript,
+                            refund: () =>
+                                [{}, new Uint8Array([3]), 0xc0] as any,
+                            refundWithoutReceiver: () =>
+                                [{}, new Uint8Array([4]), 0xc0] as any,
+                            encode: () => [] as any,
+                            options: {
+                                refundLocktime:
+                                    claimedSwap.response.timeoutBlockHeights
+                                        .refund,
+                            },
+                        },
+                        vhtlcAddress: claimedSwap.response.address,
+                    };
+                }
+            );
+
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.spendableOnly) return { vtxos: [] } as any;
+                    if (opts?.recoverableOnly) return { vtxos: [] } as any;
+                    throw new Error("scan should not issue diagnostic queries");
+                }
+            );
+        });
+
+        it("includes transaction.claimed and refundable failure statuses", async () => {
+            const results = await swaps.scanRecoverableSubmarineSwaps();
+
+            const ids = results.map((r) => r.swap.id);
+            expect(ids).toContain("claimed-swap-id");
+            expect(ids).toContain("failed-swap-id");
+        });
+
+        it("excludes pending statuses before inspecting", async () => {
+            await swaps.scanRecoverableSubmarineSwaps();
+
+            expect((swaps as any).createVHTLCScript).toHaveBeenCalledTimes(2);
+            expect(indexerProvider.getVtxos).toHaveBeenCalledTimes(2);
+        });
+
+        it("batches indexer discovery into one spendable and one recoverable query", async () => {
+            await swaps.scanRecoverableSubmarineSwaps();
+
+            expect(arkProvider.getInfo).toHaveBeenCalledTimes(1);
+            expect(indexerProvider.getVtxos).toHaveBeenCalledTimes(2);
+            expect(indexerProvider.getVtxos).toHaveBeenNthCalledWith(1, {
+                scripts: ["01", "02"],
+                spendableOnly: true,
+            });
+            expect(indexerProvider.getVtxos).toHaveBeenNthCalledWith(2, {
+                scripts: ["01", "02"],
+                recoverableOnly: true,
+            });
+        });
+
+        it("maps batched VTXOs back to the owning swap by script", async () => {
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.spendableOnly) return { vtxos: [] } as any;
+                    if (opts?.recoverableOnly) {
+                        return {
+                            vtxos: [makeVtxo(lockupTxid, 0, "01", 25000)],
+                        } as any;
+                    }
+                    throw new Error("scan should not issue diagnostic queries");
+                }
+            );
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+
+            const results = await swaps.scanRecoverableSubmarineSwaps();
+            const claimed = results.find(
+                (r) => r.swap.id === "claimed-swap-id"
+            );
+            const failed = results.find((r) => r.swap.id === "failed-swap-id");
+
+            expect(claimed).toMatchObject({
+                status: "recoverable",
+                vtxoCount: 1,
+                amountSats: 25000,
+                currentBlockHeight: 100,
+            });
+            expect(failed).toMatchObject({
+                status: "none",
+                vtxoCount: 0,
+                amountSats: 0,
+            });
+        });
+
+        it("only loads submarine swaps from the repository", async () => {
+            await swaps.scanRecoverableSubmarineSwaps();
+
+            expect(mockSwapRepository.getAllSwaps).toHaveBeenCalledWith({
+                type: "submarine",
+            });
+        });
+
+        it("does not mutate the repository", async () => {
+            await swaps.scanRecoverableSubmarineSwaps();
+
+            expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+            expect(mockSwapRepository.deleteSwap).not.toHaveBeenCalled();
+            expect(mockSwapRepository.clear).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("recoverSubmarineFunds + recoverAllSubmarineFunds", () => {
+        const lockupTxid = hex.encode(randomBytes(32));
+
+        const makeVtxo = (txid: string, vout: number) => ({
+            txid,
+            vout,
+            value: 50000,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "swept" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const claimedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "claimed-swap-id",
+            status: "transaction.claimed",
+        };
+        const failedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "failed-swap-id",
+            status: "invoice.failedToPay",
+        };
+
+        beforeEach(() => {
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+            vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+
+            vi.spyOn(swaps as any, "createVHTLCScript").mockReturnValue({
+                vhtlcScript: {
+                    claimScript: new Uint8Array([1]),
+                    pkScript: new Uint8Array([2]),
+                    refund: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    refundWithoutReceiver: () =>
+                        [{}, new Uint8Array([4]), 0xc0] as any,
+                    encode: () => [] as any,
+                    options: {
+                        refundLocktime:
+                            claimedSwap.response.timeoutBlockHeights.refund,
+                    },
+                },
+                vhtlcAddress: claimedSwap.response.address,
+            });
+
+            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+            vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
+
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.spendableOnly) return { vtxos: [] } as any;
+                    if (opts?.recoverableOnly)
+                        return { vtxos: [makeVtxo(lockupTxid, 0)] } as any;
+                    return { vtxos: [makeVtxo(lockupTxid, 0)] } as any;
+                }
+            );
+        });
+
+        describe("recoverSubmarineFunds", () => {
+            it("delegates to refundVHTLC and refunds the unspent VTXO", async () => {
+                await swaps.recoverSubmarineFunds(claimedSwap);
+
+                const joinBatch = vi.mocked((swaps as any).joinBatch);
+                expect(joinBatch).toHaveBeenCalledOnce();
+                expect(joinBatch.mock.calls[0][1].txid).toBe(lockupTxid);
+            });
+
+            it("does not mutate refundable/refunded flags on a transaction.claimed swap", async () => {
+                await swaps.recoverSubmarineFunds(claimedSwap);
+
+                // Flag-skip gate prevents updateSubmarineSwapStatus from
+                // running on success-status swaps, so the repository is
+                // never touched during stranded-fund recovery.
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+            });
+
+            it("still updates flags for legitimate failure-status refunds", async () => {
+                await swaps.recoverSubmarineFunds(failedSwap);
+
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        refundable: true,
+                        refunded: true,
+                    })
+                );
+            });
+        });
+
+        describe("recoverAllSubmarineFunds", () => {
+            it("returns one result per swap, marking successful recoveries", async () => {
+                const results = await swaps.recoverAllSubmarineFunds([
+                    claimedSwap,
+                    failedSwap,
+                ]);
+
+                expect(results).toEqual([
+                    { swapId: "claimed-swap-id", recovered: true },
+                    { swapId: "failed-swap-id", recovered: true },
+                ]);
+                expect(arkProvider.getInfo).toHaveBeenCalledTimes(1);
+            });
+
+            it("reports per-swap errors without aborting the batch", async () => {
+                // Fail the first swap deterministically: address mismatch
+                // occurs only for `claimedSwap` because we override
+                // createVHTLCScript per-call.
+                const createVHTLCScriptSpy = vi.spyOn(
+                    swaps as any,
+                    "createVHTLCScript"
+                );
+                createVHTLCScriptSpy.mockImplementationOnce(() => ({
+                    vhtlcScript: { claimScript: new Uint8Array([1]) },
+                    vhtlcAddress: "ark1-wrong-address",
+                }));
+
+                const results = await swaps.recoverAllSubmarineFunds([
+                    claimedSwap,
+                    failedSwap,
+                ]);
+
+                expect(results).toHaveLength(2);
+                expect(results[0]).toMatchObject({
+                    swapId: "claimed-swap-id",
+                    recovered: false,
+                });
+                expect(results[0].error).toMatch(/address mismatch/i);
+                expect(results[1]).toEqual({
+                    swapId: "failed-swap-id",
+                    recovered: true,
+                });
+            });
+
+            it("returns an empty array when given no swaps", async () => {
+                const results = await swaps.recoverAllSubmarineFunds([]);
+                expect(results).toEqual([]);
+            });
+        });
+    });
 });

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -33,7 +33,10 @@ import { sha256 } from "@noble/hashes/sha2.js";
 import { ripemd160 } from "@noble/hashes/legacy.js";
 import { decodeInvoice } from "../src/utils/decoding";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
-import { refundVHTLCwithOffchainTx } from "../src/utils/vhtlc";
+import {
+    createVHTLCScript as createVHTLCScriptReal,
+    refundVHTLCwithOffchainTx,
+} from "../src/utils/vhtlc";
 import { BoltzRefundError } from "../src/errors";
 
 // Mock the @arkade-os/sdk modules
@@ -222,11 +225,15 @@ describe("ArkadeSwaps", () => {
         expectedAmount: mock.invoice.amount,
         acceptZeroConf: true,
         claimPublicKey: compressedPubkeys.boltz,
+        // Prod-shaped Boltz Ark VHTLC timeouts:
+        //   refund — absolute Unix timestamp; 2023-11-14 in the past so the
+        //     default test case has CLTV satisfied (joinBatch path).
+        //   unilateral* — BIP68 relative delays (seconds, ≥ 512 type-flag).
         timeoutBlockHeights: {
-            refund: 17,
-            unilateralClaim: 21,
-            unilateralRefund: 42,
-            unilateralRefundWithoutReceiver: 63,
+            refund: 1700000000,
+            unilateralClaim: 266752,
+            unilateralRefund: 432128,
+            unilateralRefundWithoutReceiver: 518656,
         },
     };
 
@@ -243,10 +250,10 @@ describe("ArkadeSwaps", () => {
         lockupAddress: mock.lockupAddress,
         refundPublicKey: compressedPubkeys.boltz,
         timeoutBlockHeights: {
-            refund: 17,
-            unilateralClaim: 21,
-            unilateralRefund: 42,
-            unilateralRefundWithoutReceiver: 63,
+            refund: 1700000000,
+            unilateralClaim: 266752,
+            unilateralRefund: 432128,
+            unilateralRefundWithoutReceiver: 518656,
         },
     };
 
@@ -1164,10 +1171,10 @@ describe("ArkadeSwaps", () => {
                     senderPubkey: compressedPubkeys.alice,
                     serverPubkey: hex.encode(mock.pubkeys.server),
                     timeoutBlockHeights: {
-                        refund: 17,
-                        unilateralClaim: 21,
-                        unilateralRefund: 42,
-                        unilateralRefundWithoutReceiver: 63,
+                        refund: 1778741659,
+                        unilateralClaim: 266752,
+                        unilateralRefund: 432128,
+                        unilateralRefundWithoutReceiver: 518656,
                     },
                 });
 
@@ -1680,10 +1687,10 @@ describe("ArkadeSwaps", () => {
                     senderPubkey: compressedPubkeys.boltz,
                     serverPubkey: hex.encode(mock.pubkeys.server),
                     timeoutBlockHeights: {
-                        refund: 17,
-                        unilateralClaim: 21,
-                        unilateralRefund: 42,
-                        unilateralRefundWithoutReceiver: 63,
+                        refund: 1778741659,
+                        unilateralClaim: 266752,
+                        unilateralRefund: 432128,
+                        unilateralRefundWithoutReceiver: 518656,
                     },
                 });
 
@@ -2696,8 +2703,8 @@ describe("ArkadeSwaps", () => {
                 vhtlcAddress: refundableSwap.response.address,
             });
 
-            // Default: chain height past CLTV (refundLocktime=17)
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+            // Default: refundLocktime is a past timestamp (mock data), so
+            // CLTV is satisfied via wall-clock check — no chain-height query.
 
             // stub the actual refund call so we don't need real crypto
             vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
@@ -2820,11 +2827,19 @@ describe("ArkadeSwaps", () => {
                 createdAt: new Date(),
             });
 
-            beforeEach(() => {
-                // Pre-CLTV: chain tip below refundLocktime (17) so the Boltz
-                // 3-of-3 path is attempted for non-recoverable VTXOs.
-                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(10);
-            });
+            // Pre-CLTV: refundLocktime is a future Unix timestamp so the
+            // Boltz 3-of-3 path is attempted for non-recoverable VTXOs.
+            const futureRefundTimestamp = Math.floor(Date.now() / 1000) + 86400;
+            const refundableSwapPreCltv: BoltzSubmarineSwap = {
+                ...refundableSwap,
+                response: {
+                    ...refundableSwap.response,
+                    timeoutBlockHeights: {
+                        ...refundableSwap.response.timeoutBlockHeights,
+                        refund: futureRefundTimestamp,
+                    },
+                },
+            };
 
             it("should call refundVHTLCwithOffchainTx for each non-recoverable VTXO", async () => {
                 const vtxoA = makeNonRecoverableVtxo(lockupTxid, 0);
@@ -2834,7 +2849,7 @@ describe("ArkadeSwaps", () => {
                     spendable: [vtxoA, vtxoB],
                 });
 
-                await swaps.refundVHTLC(refundableSwap);
+                await swaps.refundVHTLC(refundableSwapPreCltv);
 
                 const mockRefund = vi.mocked(refundVHTLCwithOffchainTx);
                 expect(mockRefund).toHaveBeenCalledTimes(2);
@@ -2853,20 +2868,21 @@ describe("ArkadeSwaps", () => {
                     spendable: [vtxo],
                 });
 
-                await swaps.refundVHTLC(refundableSwap);
+                await swaps.refundVHTLC(refundableSwapPreCltv);
 
                 const mockRefund = vi.mocked(refundVHTLCwithOffchainTx);
                 expect(mockRefund).toHaveBeenCalledOnce();
-                expect(mockRefund.mock.calls[0][0]).toBe(refundableSwap.id);
+                expect(mockRefund.mock.calls[0][0]).toBe(
+                    refundableSwapPreCltv.id
+                );
                 expect((mockRefund.mock.calls[0][6] as any).txid).toBe(
                     lockupTxid
                 );
             });
 
             it("should skip Boltz and use joinBatch when CLTV has passed", async () => {
-                // Chain tip past refundLocktime → refundWithoutReceiver
-                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
-
+                // Default refundableSwap has past refund timestamp; CLTV
+                // satisfied via wall-clock check → refundWithoutReceiver.
                 const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
 
                 mockRefundSelection({
@@ -2894,12 +2910,17 @@ describe("ArkadeSwaps", () => {
                     new BoltzRefundError("outpoint mismatch")
                 );
 
-                // Re-check shows CLTV now satisfied
-                vi.spyOn(swapProvider, "getChainHeight")
-                    .mockResolvedValueOnce(10) // initial check
-                    .mockResolvedValueOnce(100); // re-check after Boltz rejection
+                // Re-check uses wall-clock time; advance Date.now() between
+                // the initial check (pre-CLTV) and the re-check (post-CLTV).
+                const dateSpy = vi.spyOn(Date, "now");
+                dateSpy.mockReturnValueOnce(
+                    (futureRefundTimestamp - 60) * 1000
+                );
+                dateSpy.mockReturnValueOnce(
+                    (futureRefundTimestamp + 60) * 1000
+                );
 
-                await swaps.refundVHTLC(refundableSwap);
+                await swaps.refundVHTLC(refundableSwapPreCltv);
 
                 const joinBatch = vi.mocked((swaps as any).joinBatch);
                 expect(joinBatch).toHaveBeenCalledOnce();
@@ -2917,10 +2938,10 @@ describe("ArkadeSwaps", () => {
                     new BoltzRefundError("outpoint mismatch")
                 );
 
-                // Both checks return pre-CLTV
-                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(10);
+                // Pre-CLTV the whole way through (future refund timestamp,
+                // current wall-clock isn't mocked).
 
-                await swaps.refundVHTLC(refundableSwap);
+                await swaps.refundVHTLC(refundableSwapPreCltv);
 
                 const joinBatch = vi.mocked((swaps as any).joinBatch);
                 expect(joinBatch).not.toHaveBeenCalled();
@@ -2940,21 +2961,31 @@ describe("ArkadeSwaps", () => {
                     new Error("local signing failure")
                 );
 
-                await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
-                    /local signing failure/
-                );
+                await expect(
+                    swaps.refundVHTLC(refundableSwapPreCltv)
+                ).rejects.toThrow(/local signing failure/);
             });
         });
 
         it("should skip a recoverable VTXO when pre-CLTV", async () => {
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+            const futureRefund = Math.floor(Date.now() / 1000) + 86400;
+            const preCltvSwap: BoltzSubmarineSwap = {
+                ...refundableSwap,
+                response: {
+                    ...refundableSwap.response,
+                    timeoutBlockHeights: {
+                        ...refundableSwap.response.timeoutBlockHeights,
+                        refund: futureRefund,
+                    },
+                },
+            };
             const vtxo = makeVtxo(lockupTxid, 0);
 
             mockRefundSelection({
                 recoverable: [vtxo],
             });
 
-            await swaps.refundVHTLC(refundableSwap);
+            await swaps.refundVHTLC(preCltvSwap);
 
             const joinBatch = vi.mocked((swaps as any).joinBatch);
             expect(joinBatch).not.toHaveBeenCalled();
@@ -3057,25 +3088,43 @@ describe("ArkadeSwaps", () => {
             });
         });
 
+        // Helpers for picking a refund timestamp relative to wall clock.
+        const pastRefund = () => Math.floor(Date.now() / 1000) - 1;
+        const futureRefund = () => Math.floor(Date.now() / 1000) + 86400;
+
+        const swapWithRefund = (
+            base: BoltzSubmarineSwap,
+            refund: number
+        ): BoltzSubmarineSwap => ({
+            ...base,
+            response: {
+                ...base.response,
+                timeoutBlockHeights: {
+                    ...base.response.timeoutBlockHeights,
+                    refund,
+                },
+            },
+        });
+
         it("returns recoverable for transaction.claimed plus post-CLTV VTXO", async () => {
             mockSelection({ recoverable: [makeVtxo(lockupTxid, 0, 75000)] });
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+            const refund = pastRefund();
+            const swap = swapWithRefund(claimedSwap, refund);
 
-            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+            const info = await swaps.inspectSubmarineRecovery(swap);
 
             expect(info.status).toBe("recoverable");
-            expect(info.swap).toBe(claimedSwap);
+            expect(info.swap).toBe(swap);
             expect(info.vtxoCount).toBe(1);
             expect(info.amountSats).toBe(75000);
-            expect(info.refundLocktime).toBe(17);
-            expect(info.currentBlockHeight).toBe(100);
+            expect(info.refundLocktime).toBe(refund);
         });
 
         it("returns recoverable for failed refundable status plus post-CLTV VTXO", async () => {
             mockSelection({ recoverable: [makeVtxo(lockupTxid, 0, 30000)] });
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+            const swap = swapWithRefund(failedSwap, pastRefund());
 
-            const info = await swaps.inspectSubmarineRecovery(failedSwap);
+            const info = await swaps.inspectSubmarineRecovery(swap);
 
             expect(info.status).toBe("recoverable");
             expect(info.swap.id).toBe("failed-swap-id");
@@ -3089,9 +3138,9 @@ describe("ArkadeSwaps", () => {
                     makeVtxo(lockupTxid, 1, 20000),
                 ],
             });
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+            const swap = swapWithRefund(claimedSwap, pastRefund());
 
-            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+            const info = await swaps.inspectSubmarineRecovery(swap);
 
             expect(info.status).toBe("recoverable");
             expect(info.vtxoCount).toBe(2);
@@ -3100,46 +3149,39 @@ describe("ArkadeSwaps", () => {
 
         it("returns pre_cltv when unspent VTXOs exist but locktime hasn't passed", async () => {
             mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+            const swap = swapWithRefund(claimedSwap, futureRefund());
 
-            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+            const info = await swaps.inspectSubmarineRecovery(swap);
 
             expect(info.status).toBe("pre_cltv");
             expect(info.vtxoCount).toBe(1);
-            expect(info.currentBlockHeight).toBe(5);
         });
 
         it("returns recoverable pre-CLTV when VTXOs can use Boltz 3-of-3 refund", async () => {
             mockSelection({
                 spendable: [makeVtxo(lockupTxid, 0, 50000, false, "settled")],
             });
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+            const swap = swapWithRefund(claimedSwap, futureRefund());
 
-            const info = await swaps.inspectSubmarineRecovery(claimedSwap);
+            const info = await swaps.inspectSubmarineRecovery(swap);
 
             expect(info.status).toBe("recoverable");
             expect(info.vtxoCount).toBe(1);
-            expect(info.currentBlockHeight).toBe(5);
         });
 
-        it("uses Unix time instead of chain height for timestamp locktimes", async () => {
-            const timestampSwap: BoltzSubmarineSwap = {
-                ...claimedSwap,
-                response: {
-                    ...claimedSwap.response,
-                    timeoutBlockHeights: {
-                        ...claimedSwap.response.timeoutBlockHeights,
-                        refund: Math.floor(Date.now() / 1000) - 1,
-                    },
-                },
-            };
+        it("compares refund against wall-clock Unix time, never chain height", async () => {
+            // Regression: the legacy block-height locktime path queried
+            // swapProvider.getChainHeight(). Boltz Ark VHTLCs always encode
+            // refund as a Unix timestamp, so the wall-clock check is the
+            // only path. This test pins that by failing if we ever reach
+            // for the chain tip again.
+            const swap = swapWithRefund(claimedSwap, pastRefund());
             mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
             const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
 
-            const info = await swaps.inspectSubmarineRecovery(timestampSwap);
+            const info = await swaps.inspectSubmarineRecovery(swap);
 
             expect(info.status).toBe("recoverable");
-            expect(info.currentBlockHeight).toBeUndefined();
             expect(chainHeightSpy).not.toHaveBeenCalled();
         });
 
@@ -3192,7 +3234,6 @@ describe("ArkadeSwaps", () => {
 
         it("does not mutate the repository", async () => {
             mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
 
             await swaps.inspectSubmarineRecovery(claimedSwap);
 
@@ -3326,7 +3367,6 @@ describe("ArkadeSwaps", () => {
                     throw new Error("scan should not issue diagnostic queries");
                 }
             );
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
 
             const results = await swaps.scanRecoverableSubmarineSwaps();
             const claimed = results.find(
@@ -3338,7 +3378,6 @@ describe("ArkadeSwaps", () => {
                 status: "recoverable",
                 vtxoCount: 1,
                 amountSats: 25000,
-                currentBlockHeight: 100,
             });
             expect(failed).toMatchObject({
                 status: "none",
@@ -3409,7 +3448,8 @@ describe("ArkadeSwaps", () => {
                 vhtlcAddress: claimedSwap.response.address,
             });
 
-            vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(100);
+            // Default: refundLocktime is a past timestamp (mock data) →
+            // CLTV satisfied via wall-clock check, joinBatch path.
             vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
 
             vi.mocked(indexerProvider.getVtxos).mockImplementation(
@@ -3516,10 +3556,19 @@ describe("ArkadeSwaps", () => {
                 // { swept: 0, skipped: 1 } without throwing. Aggregator must
                 // surface that as recovered:false / skipped:true rather than
                 // misreporting a successful sweep.
-                vi.spyOn(swapProvider, "getChainHeight").mockResolvedValue(5);
+                const preCltvFailed: BoltzSubmarineSwap = {
+                    ...failedSwap,
+                    response: {
+                        ...failedSwap.response,
+                        timeoutBlockHeights: {
+                            ...failedSwap.response.timeoutBlockHeights,
+                            refund: Math.floor(Date.now() / 1000) + 86400,
+                        },
+                    },
+                };
 
                 const results = await swaps.recoverAllSubmarineFunds([
-                    failedSwap,
+                    preCltvFailed,
                 ]);
 
                 expect(results).toEqual([
@@ -3532,6 +3581,189 @@ describe("ArkadeSwaps", () => {
                 const joinBatch = vi.mocked((swaps as any).joinBatch);
                 expect(joinBatch).not.toHaveBeenCalled();
             });
+        });
+    });
+
+    // =========================================================================
+    // Regressions: VHTLC refund readiness uses wall-clock time, not chain
+    // height. Boltz Ark VHTLCs encode `refund` as an absolute Unix timestamp.
+    // =========================================================================
+    describe("Submarine refund readiness — timestamp vs chain height", () => {
+        const lockupTxid = hex.encode(randomBytes(32));
+
+        const makeVtxo = (txid: string, vout: number, value = 50000) => ({
+            txid,
+            vout,
+            value,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "settled" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const failedSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            id: "regression-failed-swap-id",
+            status: "invoice.failedToPay",
+        };
+
+        const swapWithRefund = (refund: number): BoltzSubmarineSwap => ({
+            ...failedSwap,
+            response: {
+                ...failedSwap.response,
+                timeoutBlockHeights: {
+                    ...failedSwap.response.timeoutBlockHeights,
+                    refund,
+                },
+            },
+        });
+
+        beforeEach(() => {
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+            vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+
+            vi.spyOn(swaps as any, "createVHTLCScript").mockReturnValue({
+                vhtlcScript: {
+                    claimScript: new Uint8Array([1]),
+                    pkScript: new Uint8Array([2]),
+                    refund: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    refundWithoutReceiver: () =>
+                        [{}, new Uint8Array([4]), 0xc0] as any,
+                    encode: () => [] as any,
+                    options: {
+                        refundLocktime:
+                            failedSwap.response.timeoutBlockHeights.refund,
+                    },
+                },
+                vhtlcAddress: failedSwap.response.address,
+            });
+            vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.spendableOnly) return { vtxos: [] } as any;
+                    if (opts?.recoverableOnly)
+                        return { vtxos: [makeVtxo(lockupTxid, 0)] } as any;
+                    return { vtxos: [makeVtxo(lockupTxid, 0)] } as any;
+                }
+            );
+        });
+
+        it("refundVHTLC evaluates CLTV against Date.now(), not chain height", async () => {
+            // Refund timestamp 1 second in the past per mocked Date.now().
+            const refundTs = 1_800_000_000;
+            const dateSpy = vi.spyOn(Date, "now");
+            dateSpy.mockReturnValue((refundTs + 1) * 1000);
+            const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
+
+            const swap = swapWithRefund(refundTs);
+            const outcome = await swaps.refundVHTLC(swap);
+
+            // CLTV satisfied → joinBatch path; no Boltz 3-of-3 attempt.
+            expect(outcome.swept).toBe(1);
+            expect(outcome.skipped).toBe(0);
+            expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            expect(chainHeightSpy).not.toHaveBeenCalled();
+        });
+
+        it("refundVHTLC defers when wall clock is below the refund timestamp", async () => {
+            const refundTs = 1_800_000_000;
+            const dateSpy = vi.spyOn(Date, "now");
+            dateSpy.mockReturnValue((refundTs - 1) * 1000);
+            const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
+
+            // Use a recoverable VTXO so the Boltz 3-of-3 path is blocked
+            // (canRecoverViaBoltz3of3 returns false) — the only outcome is
+            // a deferred skip when CLTV hasn't been reached.
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.recoverableOnly) {
+                        return {
+                            vtxos: [
+                                {
+                                    ...makeVtxo(lockupTxid, 0),
+                                    virtualStatus: {
+                                        state: "swept" as const,
+                                    },
+                                },
+                            ],
+                        } as any;
+                    }
+                    return { vtxos: [] } as any;
+                }
+            );
+
+            const swap = swapWithRefund(refundTs);
+            const outcome = await swaps.refundVHTLC(swap);
+
+            expect(outcome.swept).toBe(0);
+            expect(outcome.skipped).toBe(1);
+            expect(chainHeightSpy).not.toHaveBeenCalled();
+        });
+
+        it("scanRecoverableSubmarineSwaps does not query chain height", async () => {
+            vi.mocked(mockSwapRepository.getAllSwaps).mockResolvedValue([
+                swapWithRefund(1_800_000_000),
+            ]);
+            vi.mocked(indexerProvider.getVtxos).mockImplementation(
+                async (opts: any) => {
+                    if (opts?.spendableOnly) return { vtxos: [] } as any;
+                    if (opts?.recoverableOnly) return { vtxos: [] } as any;
+                    throw new Error("scan should not issue diagnostic queries");
+                }
+            );
+            const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
+
+            await swaps.scanRecoverableSubmarineSwaps();
+
+            expect(chainHeightSpy).not.toHaveBeenCalled();
+        });
+
+        it("recoverAllSubmarineFunds does not query chain height", async () => {
+            const refundTs = 1_800_000_000;
+            const dateSpy = vi.spyOn(Date, "now");
+            dateSpy.mockReturnValue((refundTs + 1) * 1000);
+            const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
+
+            const results = await swaps.recoverAllSubmarineFunds([
+                swapWithRefund(refundTs),
+            ]);
+
+            expect(results[0]).toMatchObject({ recovered: true });
+            expect(chainHeightSpy).not.toHaveBeenCalled();
+        });
+
+        it("handles prod-shaped Boltz Ark VHTLC timeouts (timestamp + BIP68 seconds)", () => {
+            // refund: absolute Unix timestamp (mainnet-shaped, ~2026-05-14).
+            // unilateral*: BIP68 relative delays in seconds, multiples of 512.
+            const prodTimeouts = {
+                refund: 1778741659,
+                unilateralClaim: 266752,
+                unilateralRefund: 432128,
+                unilateralRefundWithoutReceiver: 518656,
+            };
+            // Sanity-check: BIP68 type-flag boundary is 512.
+            expect(prodTimeouts.unilateralClaim).toBeGreaterThanOrEqual(512);
+            expect(prodTimeouts.unilateralRefund).toBeGreaterThanOrEqual(512);
+            expect(
+                prodTimeouts.unilateralRefundWithoutReceiver
+            ).toBeGreaterThanOrEqual(512);
+            expect(prodTimeouts.unilateralClaim % 512).toBe(0);
+            expect(prodTimeouts.unilateralRefund % 512).toBe(0);
+            expect(prodTimeouts.unilateralRefundWithoutReceiver % 512).toBe(0);
+
+            // The real script builder accepts prod values without throwing.
+            // Bypass the describe-scoped createVHTLCScript spy.
+            expect(() =>
+                createVHTLCScriptReal({
+                    network: "regtest",
+                    preimageHash: mockPreimageHash,
+                    receiverPubkey: compressedPubkeys.boltz,
+                    senderPubkey: compressedPubkeys.alice,
+                    serverPubkey: hex.encode(mock.pubkeys.server),
+                    timeoutBlockHeights: prodTimeouts,
+                })
+            ).not.toThrow();
         });
     });
 });

--- a/test/e2e/arkade-swaps.test.ts
+++ b/test/e2e/arkade-swaps.test.ts
@@ -740,6 +740,100 @@ describe("ArkadeSwaps", () => {
     });
 
     // ==========================================
+    // Submarine Recovery
+    // ==========================================
+
+    describe("Submarine Recovery", () => {
+        it(
+            "should inspect, scan, and recover funds stranded at a failed submarine swap's VHTLC",
+            { timeout: 30_000 },
+            async () => {
+                const amount = 1000;
+                const fundAmount = amount + 100;
+                await fundWallet(fundAmount);
+
+                // Cancel the invoice so any payment attempt by Boltz fails.
+                const { invoice, r_hash } =
+                    await getNewLightningInvoice(amount);
+                await cancelInvoice(r_hash);
+
+                // Use createSubmarineSwap directly so sendLightningPayment's
+                // catch-block auto-refund doesn't pre-empt us — we want the
+                // funds to remain stranded at the VHTLC so the recovery APIs
+                // have something to act on.
+                const pendingSwap = await swaps.createSubmarineSwap({
+                    invoice,
+                });
+                const balanceBeforeLockup = await wallet.getBalance();
+
+                await wallet.send({
+                    address: pendingSwap.response.address,
+                    amount: pendingSwap.response.expectedAmount,
+                });
+
+                // Boltz tries to pay the cancelled invoice → invoice.failedToPay.
+                // Sync the local repo so the recovery APIs see the new status.
+                await waitForSwapStatus(
+                    pendingSwap.id,
+                    "invoice.failedToPay",
+                    10_000
+                );
+                await swaps.refreshSwapsStatus();
+
+                const failedSwap = (await swaps.getSwapHistory()).find(
+                    (s): s is BoltzSubmarineSwap => s.id === pendingSwap.id
+                );
+                expect(failedSwap?.status).toBe("invoice.failedToPay");
+
+                // inspectSubmarineRecovery: pre-CLTV failure with a regular
+                // spendable VTXO at the lockup is recoverable via Boltz 3-of-3.
+                const info = await swaps.inspectSubmarineRecovery(failedSwap!);
+                expect(info.status).toBe("recoverable");
+                expect(info.swap.id).toBe(pendingSwap.id);
+                expect(info.vtxoCount).toBeGreaterThanOrEqual(1);
+                expect(info.amountSats).toBeGreaterThanOrEqual(
+                    pendingSwap.response.expectedAmount
+                );
+
+                // scanRecoverableSubmarineSwaps: bulk scan should also flag it
+                // as recoverable.
+                const scan = await swaps.scanRecoverableSubmarineSwaps();
+                const scanEntry = scan.find(
+                    (s) => s.swap.id === pendingSwap.id
+                );
+                expect(scanEntry?.status).toBe("recoverable");
+                expect(scanEntry?.vtxoCount).toBeGreaterThanOrEqual(1);
+
+                // recoverAllSubmarineFunds: sweep the VHTLC and report success
+                // through the per-swap result aggregator.
+                const results = await swaps.recoverAllSubmarineFunds([
+                    failedSwap!,
+                ]);
+                expect(results).toHaveLength(1);
+                expect(results[0]).toMatchObject({
+                    swapId: pendingSwap.id,
+                    recovered: true,
+                    skipped: false,
+                });
+                expect(results[0].error).toBeUndefined();
+
+                // Funds should land back in the wallet.
+                await waitForBalance(
+                    () => wallet.getBalance(),
+                    balanceBeforeLockup.available - 200,
+                    5_000
+                );
+
+                // Post-recovery: the lockup VTXO is now spent, so a fresh
+                // inspect classifies the swap as already_spent.
+                const post = await swaps.inspectSubmarineRecovery(failedSwap!);
+                expect(post.status).toBe("already_spent");
+                expect(post.vtxoCount).toBe(0);
+            }
+        );
+    });
+
+    // ==========================================
     // Chain Operations
     // ==========================================
 


### PR DESCRIPTION
## Summary

Submarine swaps can strand funds in two ways: a swap fails before the CLTV expires and is never refunded, or extra sats are deposited to a lockup address after the swap already settled. Neither case was previously recoverable without manual intervention.

This PR adds explicit, side-effect-free recovery APIs:

- `inspectSubmarineRecovery(swap)` — classifies a single swap as `recoverable`, `pre_cltv`, `none`, `already_spent`, or `invalid_swap`, querying only the local repository and the Ark indexer (no Boltz dependency, so it works even after Boltz purges the swap).
- `scanRecoverableSubmarineSwaps()` — runs inspection across all stored swaps and returns those with actionable VTXOs.
- `recoverSubmarineFunds(swap)` — refunds one swap via the `refundWithoutReceiver` unilateral path.
- `recoverAllSubmarineFunds(swaps)` — processes a batch sequentially; a single failure produces a `SubmarineRecoveryResult` entry without aborting the rest.

`refundVHTLC` is also updated to skip the `refundable`/`refunded` flag write on `transaction.claimed` swaps so that sweeping stranded extras does not muddle swap history.

All APIs are wired through `IArkadeSwaps`, `ExpoArkadeSwaps`, the service-worker message handler and runtime. The service-worker handler now also exempts the full set of long-running message types (claim, refund, recovery, wait, restore, and `SM-WAIT_FOR_COMPLETION`) from the bus-level timeout, preventing spurious timeouts on operations that legitimately block on chain or Ark server events.

## Note about timeouts

The usage of `sendMessageDirect()` will be fixed in a separate PR due to the amount of code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submarine swap recovery: inspect diagnostics, scan local repository for recoverable swaps, and recover funds with per-swap structured outcomes; refund operations now return detailed outcomes and support long-running recovery workflows.

* **Documentation**
  * Added guidance for manual recovery of stranded submarine/VHTLC funds.

* **Tests**
  * Added unit and e2e tests covering recovery flows, locktime handling, batching, validation, and per-swap result semantics.

* **Chores**
  * .gitignore updated to ignore additional AI-related files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->