### PR TITLE
fix(serviceWorker): exempt long-running messages from timeouts

### DIFF
--- a/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -518,6 +518,24 @@ export type ArkadeSwapsUpdaterResponse =
     | ResponseSwapManagerGetStats
     | ResponseSwapManagerWaitForCompletion;
 
+export const LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES: ReadonlySet<
+    ArkadeSwapsUpdaterRequest["type"]
+> = new Set([
+    "SEND_LIGHTNING_PAYMENT",
+    "CLAIM_VHTLC",
+    "REFUND_VHTLC",
+    "WAIT_AND_CLAIM",
+    "WAIT_FOR_SWAP_SETTLEMENT",
+    "RESTORE_SWAPS",
+    "WAIT_AND_CLAIM_CHAIN",
+    "WAIT_AND_CLAIM_ARK",
+    "WAIT_AND_CLAIM_BTC",
+    "CLAIM_ARK",
+    "CLAIM_BTC",
+    "REFUND_ARK",
+    "SM-WAIT_FOR_COMPLETION",
+]);
+
 type BoltzSwap = BoltzReverseSwap | BoltzSubmarineSwap | BoltzChainSwap;
 
 export type SwapManagerEventMessage =
@@ -615,6 +633,15 @@ export class ArkadeSwapsMessageHandler
     async tick(_now: number) {
         // Event-driven handler; no periodic work required from the service worker tick.
         return [];
+    }
+
+    // Flows that surrender control to Boltz, the Ark server, or other
+    // participants in a batch round: quiet gaps between protocol events can
+    // easily exceed the bus-level messageTimeoutMs. Liveness is covered
+    // out-of-band by the page-side PING / MESSAGE_BUS_NOT_INITIALIZED path
+    // triggered by concurrent short requests (GET_FEES, GET_SWAP_STATUS, ...).
+    isLongRunning(message: ArkadeSwapsUpdaterRequest): boolean {
+        return LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES.has(message.type);
     }
 
     private tagged(

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -22,6 +22,7 @@ import {
     ArkadeSwapsUpdaterResponse,
     DEFAULT_MESSAGE_TAG,
     RequestInitArkSwaps,
+    LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES,
 } from "./arkade-swaps-message-handler";
 import type {
     ResponseArkToBtc,
@@ -73,6 +74,9 @@ function isMessageBusNotInitializedError(error: unknown): boolean {
         error.message.includes(MESSAGE_BUS_NOT_INITIALIZED)
     );
 }
+
+const DEFAULT_MESSAGE_TIMEOUT_MS = 30_000;
+const NO_MESSAGE_TIMEOUT_MS = 0;
 
 const DEDUPABLE_REQUEST_TYPES: ReadonlySet<string> = new Set([
     "GET_FEES",
@@ -959,7 +963,8 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
     }
 
     private sendMessageDirect(
-        request: ArkadeSwapsUpdaterRequest
+        request: ArkadeSwapsUpdaterRequest,
+        timeoutMs: number
     ): Promise<ArkadeSwapsUpdaterResponse> {
         return new Promise((resolve, reject) => {
             const cleanup = () => {
@@ -970,14 +975,19 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
                 );
             };
 
-            const timeoutId = setTimeout(() => {
-                cleanup();
-                reject(
-                    new ServiceWorkerTimeoutError(
-                        `Service worker message timed out (${request.type})`
-                    )
-                );
-            }, 30_000);
+            // Match the SDK MessageBus convention: non-positive timeouts
+            // disable the deadline for flows that wait on remote peers.
+            const timeoutId =
+                timeoutMs > 0
+                    ? setTimeout(() => {
+                          cleanup();
+                          reject(
+                              new ServiceWorkerTimeoutError(
+                                  `Service worker message timed out (${request.type})`
+                              )
+                          );
+                      }, timeoutMs)
+                    : undefined;
 
             const messageHandler = (event: MessageEvent) => {
                 const response = event.data as
@@ -1079,10 +1089,16 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
             }
         }
 
+        const timeoutMs = LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES.has(
+            request.type
+        )
+            ? NO_MESSAGE_TIMEOUT_MS
+            : DEFAULT_MESSAGE_TIMEOUT_MS;
+
         const maxRetries = 2;
         for (let attempt = 0; ; attempt++) {
             try {
-                return await this.sendMessageDirect(request);
+                return await this.sendMessageDirect(request, timeoutMs);
             } catch (error: any) {
                 if (
                     !isMessageBusNotInitializedError(error) ||
@@ -1111,7 +1127,10 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
                 payload: this.initPayload,
             };
 
-            await this.sendMessageDirect(initMessage);
+            await this.sendMessageDirect(
+                initMessage,
+                DEFAULT_MESSAGE_TIMEOUT_MS
+            );
         })().finally(() => {
             this.reinitPromise = null;
         });

--- a/test/serviceWorker/arkade-swaps-message-handler.test.ts
+++ b/test/serviceWorker/arkade-swaps-message-handler.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ArkadeSwapsMessageHandler } from "../../src/serviceWorker/arkade-swaps-message-handler";
+import {
+    ArkadeSwapsMessageHandler,
+    LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES,
+} from "../../src/serviceWorker/arkade-swaps-message-handler";
 import { SwapRepository } from "../../src/repositories/swap-repository";
 import { BoltzReverseSwap } from "../../src/types";
 import { BoltzSwapStatus } from "../../src/boltz-swap-provider";
@@ -37,5 +40,29 @@ describe("ArkadeSwapsMessageHandler broadcastEvent", () => {
         expect(postMessage).toHaveBeenCalledWith(
             expect.objectContaining({ type: "SM-EVENT-SWAP_UPDATE" })
         );
+    });
+});
+
+describe("ArkadeSwapsMessageHandler long-running requests", () => {
+    it("uses the exported long-running request set for bus timeout opt-out", () => {
+        const handler = new ArkadeSwapsMessageHandler({} as SwapRepository);
+
+        for (const type of LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES) {
+            expect(
+                handler.isLongRunning({
+                    id: "req",
+                    tag: handler.messageTag,
+                    type,
+                } as any)
+            ).toBe(true);
+        }
+
+        expect(
+            handler.isLongRunning({
+                id: "req",
+                tag: handler.messageTag,
+                type: "GET_FEES",
+            } as any)
+        ).toBe(false);
     });
 });

--- a/test/serviceWorker/arkade-swaps-runtime.test.ts
+++ b/test/serviceWorker/arkade-swaps-runtime.test.ts
@@ -738,6 +738,86 @@ describe("in-flight request deduplication", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Message timeouts
+// ---------------------------------------------------------------------------
+
+describe("message timeouts", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it("times out non-long-running requests after the default deadline", async () => {
+        vi.useFakeTimers();
+
+        const { navigatorServiceWorker, serviceWorker } =
+            createServiceWorkerHarness();
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        const assertion = runtime.getFees().then(
+            () => {
+                throw new Error("Expected getFees to time out");
+            },
+            (error) => {
+                expect(error.message).toContain("Cannot get fees");
+                expect(error.cause).toBeInstanceOf(ServiceWorkerTimeoutError);
+                expect(error.cause.message).toContain("GET_FEES");
+            }
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        await assertion;
+    });
+
+    it("does not apply the page-side deadline to long-running requests", async () => {
+        vi.useFakeTimers();
+
+        const { navigatorServiceWorker, serviceWorker, emit } =
+            createServiceWorkerHarness();
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        const promise = runtime.waitForSwapSettlement({
+            id: "swap-1",
+        } as BoltzSubmarineSwap);
+        const assertion = expect(promise).resolves.toEqual({
+            preimage: "preimage",
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        const request = serviceWorker.postMessage.mock.calls
+            .map(([message]: any[]) => message)
+            .find(
+                (message: any) => message.type === "WAIT_FOR_SWAP_SETTLEMENT"
+            );
+
+        expect(request).toEqual(
+            expect.objectContaining({ type: "WAIT_FOR_SWAP_SETTLEMENT" })
+        );
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        emit({
+            id: request.id,
+            tag: TAG,
+            type: "SWAP_SETTLED",
+            payload: { preimage: "preimage" },
+        });
+
+        await assertion;
+    });
+});
+
+// ---------------------------------------------------------------------------
 // Preflight ping
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Mirror of arkade-os/ts-sdk#446 for boltz-swap. Settlement-class flows in the swap layer (lightning payments, VHTLC claims/refunds, chain-swap waits, swap-manager completion, etc.) surrender control to Boltz, the Ark server, or the other participants in a batch round. Quiet gaps between protocol events can easily exceed the 30s bus deadline, so the page-side `setTimeout` was firing on legitimately progressing operations.

Both sides of the bus now skip the timeout for these requests:

- Worker side: `ArkadeSwapsMessageHandler.isLongRunning()` opts out of the SDK MessageBus deadline (the hook landed in ts-sdk#446).
- Page side: `sendMessageDirect` takes a `timeoutMs` parameter; `sendMessageWithRetry` passes `0` (the SDK's "no deadline" sentinel) when the request type is in the shared `LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES` set, and the default 30s otherwise.

Service-worker death is still detected out-of-band: every send starts with a 2s `pingServiceWorker()`, and a restarted worker returns `MESSAGE_BUS_NOT_INITIALIZED` synchronously on the next concurrent short request (`GET_FEES`, `GET_SWAP_STATUS`, …), which triggers `reinitialize()` + retry.

## Related

- arkade-os/ts-sdk#446 — the corresponding ts-sdk change this PR mirrors
- #133 — loosely related (same service-worker plumbing area)