### PR TITLE
Prod endpoint + polling logic

### DIFF
--- a/src/boltz-swap-provider.ts
+++ b/src/boltz-swap-provider.ts
@@ -1,5 +1,10 @@
 import { Transaction } from "@arkade-os/sdk";
-import { NetworkError, SchemaError, SwapError } from "./errors";
+import {
+    NetworkError,
+    SchemaError,
+    SwapError,
+    SwapNotFoundError,
+} from "./errors";
 import {
     Chain,
     ChainFeesResponse,
@@ -998,9 +1003,21 @@ export const isCreateSwapsRestoreResponse = (
 };
 
 const BASE_URLS: Partial<Record<Network, string>> = {
-    bitcoin: "https://api.ark.boltz.exchange",
+    bitcoin: "https://api.boltz.exchange",
     mutinynet: "https://api.boltz.mutinynet.arkade.sh",
     regtest: "http://localhost:9069",
+};
+
+// Boltz's body for an unknown swap looks like
+//   {"error":"could not find swap with id: <id>"}
+// Match defensively on either the parsed JSON field or the raw message so a
+// 404 from a renamed route or misconfigured proxy does NOT trip the safety net.
+const isSwapNotFoundBody = (error: NetworkError): boolean => {
+    const needle = "could not find swap";
+    const fromJson = error.errorData?.error;
+    if (typeof fromJson === "string" && fromJson.toLowerCase().includes(needle))
+        return true;
+    return error.message.toLowerCase().includes(needle);
 };
 
 /**
@@ -1111,12 +1128,31 @@ export class BoltzSwapProvider {
         return res;
     }
 
-    /** Queries the current status of a swap by ID. */
+    /**
+     * Queries the current status of a swap by ID.
+     *
+     * @throws {SwapNotFoundError} when Boltz responds with HTTP 404 and a body
+     * matching the "could not find swap" pattern. Distinct from a generic 404
+     * so callers (e.g. SwapManager polling) can drive a per-swap unknown-to-
+     * provider counter without tripping on transient route or proxy errors.
+     */
     async getSwapStatus(id: string): Promise<GetSwapStatusResponse> {
-        const response = await this.request<GetSwapStatusResponse>(
-            `/v2/swap/${id}`,
-            "GET"
-        );
+        let response: GetSwapStatusResponse;
+        try {
+            response = await this.request<GetSwapStatusResponse>(
+                `/v2/swap/${id}`,
+                "GET"
+            );
+        } catch (error) {
+            if (
+                error instanceof NetworkError &&
+                error.statusCode === 404 &&
+                isSwapNotFoundBody(error)
+            ) {
+                throw new SwapNotFoundError(id, error.errorData);
+            }
+            throw error;
+        }
         if (!isGetSwapStatusResponse(response))
             throw new SchemaError({
                 message: `error fetching status for swap: ${id}`,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -78,6 +78,30 @@ export class NetworkError extends Error {
     }
 }
 
+/**
+ * Thrown when Boltz responds to `GET /v2/swap/{id}` with HTTP 404 and a body
+ * matching `{"error":"could not find swap with id: ..."}`. Signals that the
+ * configured Boltz instance has no record of this swap — typically because
+ * the swap was created against a different Boltz endpoint. Distinct from a
+ * generic 404 (route change, proxy misconfig) so the polling loop can drive
+ * a per-swap "unknown to provider" counter without conflating it with
+ * transient network errors.
+ */
+export class SwapNotFoundError extends NetworkError {
+    /** The swap ID Boltz did not recognise. */
+    public readonly swapId: string;
+
+    constructor(swapId: string, errorData?: any) {
+        super(
+            `Boltz returned 404 for swap '${swapId}': swap unknown to this Boltz instance`,
+            404,
+            errorData
+        );
+        this.name = "SwapNotFoundError";
+        this.swapId = swapId;
+    }
+}
+
 /** Thrown when the Boltz API returns a response that doesn't match the expected schema. */
 export class SchemaError extends SwapError {
     constructor(options: ErrorOptions = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
     InsufficientFundsError,
     NetworkError,
     PreimageFetchError,
+    SwapNotFoundError,
     TransactionFailedError,
     BoltzRefundError,
 } from "./errors";

--- a/src/swap-manager.ts
+++ b/src/swap-manager.ts
@@ -1372,10 +1372,17 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        // Remove from monitoring first so any in-flight poll/WS handler
-        // for this ID becomes a no-op.
+        const oldStatus = swap.status;
+        // `swap.expired` is final for submarine, reverse, and chain swaps
+        // (see is*FinalStatus helpers). On next start the swap is loaded
+        // with a final status and won't be re-added to monitoredSwaps.
+        swap.status = "swap.expired";
+
+        // Remove from monitoring up-front so any in-flight poll/WS handler
+        // for this ID becomes a no-op. Subscribers are NOT cleared yet —
+        // we still need to deliver the terminal status update to them
+        // (e.g. waitForSwapCompletion is awaiting that callback).
         this.monitoredSwaps.delete(swap.id);
-        this.swapSubscriptions.delete(swap.id);
         const retryTimer = this.pollRetryTimers.get(swap.id);
         if (retryTimer) {
             clearTimeout(retryTimer);
@@ -1383,12 +1390,26 @@ export class SwapManager implements SwapManagerClient {
         }
         this.notFoundCounts.delete(swap.id);
 
-        // `swap.expired` is final for submarine, reverse, and chain swaps
-        // (see is*FinalStatus helpers). On next start the swap is loaded
-        // with a final status and won't be re-added to monitoredSwaps.
-        swap.status = "swap.expired";
+        // Mirror the emission shape of handleSwapStatusUpdate so listeners
+        // and per-swap subscribers see the terminal transition even though
+        // we bypassed that path (we did so to skip the auto-action branch).
+        this.swapUpdateListeners.forEach((listener) =>
+            listener(swap, oldStatus)
+        );
+        const subscribers = this.swapSubscriptions.get(swap.id);
+        if (subscribers) {
+            subscribers.forEach((callback) => {
+                try {
+                    callback(swap, oldStatus);
+                } catch (subscriberError) {
+                    logger.error(
+                        `Error in swap subscription callback for ${swap.id}:`,
+                        subscriberError
+                    );
+                }
+            });
+        }
 
-        const error = new SwapNotFoundError(swap.id);
         try {
             await this.saveSwap(swap);
         } catch (saveError) {
@@ -1402,7 +1423,11 @@ export class SwapManager implements SwapManagerClient {
             `Swap ${swap.id}: marked failed after ${SwapManager.NOT_FOUND_THRESHOLD} consecutive Boltz 404s — swap is unknown to the configured Boltz instance`
         );
 
+        const error = new SwapNotFoundError(swap.id);
         this.swapFailedListeners.forEach((listener) => listener(swap, error));
+
+        // Subscribers have been notified; safe to drop the set now.
+        this.swapSubscriptions.delete(swap.id);
     }
 
     /**

--- a/src/swap-manager.ts
+++ b/src/swap-manager.ts
@@ -1296,10 +1296,7 @@ export class SwapManager implements SwapManagerClient {
             // On 429 (rate-limited), schedule a single retry for this
             // swap rather than waiting the full poll interval. This
             // avoids a 30s gap in status tracking after a burst.
-            if (
-                error instanceof NetworkError &&
-                error.statusCode === 429
-            ) {
+            if (error instanceof NetworkError && error.statusCode === 429) {
                 logger.warn(
                     `Rate-limited polling swap ${swap.id}, retrying in 2s`
                 );
@@ -1310,8 +1307,9 @@ export class SwapManager implements SwapManagerClient {
                     setTimeout(async () => {
                         this.pollRetryTimers.delete(swap.id);
                         try {
-                            const retry =
-                                await this.swapProvider.getSwapStatus(swap.id);
+                            const retry = await this.swapProvider.getSwapStatus(
+                                swap.id
+                            );
                             this.notFoundCounts.delete(swap.id);
                             if (retry.status !== swap.status) {
                                 await this.handleSwapStatusUpdate(

--- a/src/swap-manager.ts
+++ b/src/swap-manager.ts
@@ -19,7 +19,7 @@ import {
     BoltzSubmarineSwap,
     BoltzSwap,
 } from "./types";
-import { NetworkError } from "./errors";
+import { NetworkError, SwapNotFoundError } from "./errors";
 import { logger } from "./logger";
 
 /**
@@ -165,6 +165,15 @@ export interface SwapManagerCallbacks {
  * for both reconnection and polling intervals.
  */
 export class SwapManager implements SwapManagerClient {
+    /**
+     * Number of consecutive Boltz 404s for a single swap ID before the
+     * polling loop gives up and transitions the swap to a terminal state.
+     * At the default 30s poll cadence this is roughly a 5-minute grace
+     * window — long enough to ride out a transient Boltz blip, short
+     * enough that a real "swap unknown to this provider" surfaces quickly.
+     */
+    private static readonly NOT_FOUND_THRESHOLD = 10;
+
     private readonly swapProvider: BoltzSwapProvider;
     private readonly config: SwapManagerConfig;
 
@@ -184,6 +193,13 @@ export class SwapManager implements SwapManagerClient {
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private initialPollTimer: ReturnType<typeof setTimeout> | null = null;
     private pollRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    // Per-swap counter of consecutive `SwapNotFoundError` responses from
+    // `getSwapStatus`. Reset on any successful poll. Once a swap reaches
+    // `NOT_FOUND_THRESHOLD` consecutive 404s the safety net trips and the
+    // swap is transitioned to `swap.expired` (terminal) and dropped from
+    // monitoring — typically the canonical failure mode after a Boltz
+    // endpoint switch, where old swap IDs are unknown to the new instance.
+    private notFoundCounts = new Map<string, number>();
     private isRunning = false;
     private currentReconnectDelay: number;
     private currentPollRetryDelay: number;
@@ -436,6 +452,7 @@ export class SwapManager implements SwapManagerClient {
             clearTimeout(timer);
         }
         this.pollRetryTimers.clear();
+        this.notFoundCounts.clear();
     }
 
     /**
@@ -509,6 +526,7 @@ export class SwapManager implements SwapManagerClient {
             clearTimeout(retryTimer);
             this.pollRetryTimers.delete(swapId);
         }
+        this.notFoundCounts.delete(swapId);
         logger.log(`Removed swap ${swapId} from monitoring`);
     }
 
@@ -871,6 +889,10 @@ export class SwapManager implements SwapManagerClient {
         swap: BoltzSwap,
         newStatus: BoltzSwapStatus
     ): Promise<void> {
+        // Any real status update (poll or WebSocket) means Boltz still
+        // recognises this swap — clear the unknown-to-provider counter.
+        this.notFoundCounts.delete(swap.id);
+
         const oldStatus = swap.status;
 
         // Skip if status hasn't changed
@@ -1249,61 +1271,140 @@ export class SwapManager implements SwapManagerClient {
         if (this.monitoredSwaps.size === 0) return;
 
         const pollPromises = Array.from(this.monitoredSwaps.values()).map(
-            async (swap) => {
-                try {
-                    const statusResponse =
-                        await this.swapProvider.getSwapStatus(swap.id);
-
-                    if (statusResponse.status !== swap.status) {
-                        await this.handleSwapStatusUpdate(
-                            swap,
-                            statusResponse.status
-                        );
-                    }
-                } catch (error) {
-                    // On 429 (rate-limited), schedule a single retry for this
-                    // swap rather than waiting the full poll interval. This
-                    // avoids a 30s gap in status tracking after a burst.
-                    if (
-                        error instanceof NetworkError &&
-                        error.statusCode === 429
-                    ) {
-                        logger.warn(
-                            `Rate-limited polling swap ${swap.id}, retrying in 2s`
-                        );
-                        const existing = this.pollRetryTimers.get(swap.id);
-                        if (existing) clearTimeout(existing);
-                        this.pollRetryTimers.set(
-                            swap.id,
-                            setTimeout(async () => {
-                                this.pollRetryTimers.delete(swap.id);
-                                try {
-                                    const retry =
-                                        await this.swapProvider.getSwapStatus(
-                                            swap.id
-                                        );
-                                    if (retry.status !== swap.status) {
-                                        await this.handleSwapStatusUpdate(
-                                            swap,
-                                            retry.status
-                                        );
-                                    }
-                                } catch (retryError) {
-                                    logger.error(
-                                        `Retry poll for swap ${swap.id} also failed:`,
-                                        retryError
-                                    );
-                                }
-                            }, 2000)
-                        );
-                    } else {
-                        logger.error(`Failed to poll swap ${swap.id}:`, error);
-                    }
-                }
-            }
+            (swap) => this.pollSingleSwap(swap)
         );
 
         await Promise.allSettled(pollPromises);
+    }
+
+    private async pollSingleSwap(swap: BoltzSwap): Promise<void> {
+        try {
+            const statusResponse = await this.swapProvider.getSwapStatus(
+                swap.id
+            );
+            // A successful response means Boltz still recognises this swap
+            // — clear the consecutive-not-found counter.
+            this.notFoundCounts.delete(swap.id);
+            if (statusResponse.status !== swap.status) {
+                await this.handleSwapStatusUpdate(swap, statusResponse.status);
+            }
+        } catch (error) {
+            if (error instanceof SwapNotFoundError) {
+                await this.handleSwapNotFound(swap);
+                return;
+            }
+            // On 429 (rate-limited), schedule a single retry for this
+            // swap rather than waiting the full poll interval. This
+            // avoids a 30s gap in status tracking after a burst.
+            if (
+                error instanceof NetworkError &&
+                error.statusCode === 429
+            ) {
+                logger.warn(
+                    `Rate-limited polling swap ${swap.id}, retrying in 2s`
+                );
+                const existing = this.pollRetryTimers.get(swap.id);
+                if (existing) clearTimeout(existing);
+                this.pollRetryTimers.set(
+                    swap.id,
+                    setTimeout(async () => {
+                        this.pollRetryTimers.delete(swap.id);
+                        try {
+                            const retry =
+                                await this.swapProvider.getSwapStatus(swap.id);
+                            this.notFoundCounts.delete(swap.id);
+                            if (retry.status !== swap.status) {
+                                await this.handleSwapStatusUpdate(
+                                    swap,
+                                    retry.status
+                                );
+                            }
+                        } catch (retryError) {
+                            if (retryError instanceof SwapNotFoundError) {
+                                await this.handleSwapNotFound(swap);
+                                return;
+                            }
+                            logger.error(
+                                `Retry poll for swap ${swap.id} also failed:`,
+                                retryError
+                            );
+                        }
+                    }, 2000)
+                );
+            } else {
+                logger.error(`Failed to poll swap ${swap.id}:`, error);
+            }
+        }
+    }
+
+    /**
+     * Increment the consecutive-not-found counter and, once the threshold is
+     * reached, transition the swap to a terminal state and stop polling it.
+     * Driven from {@link pollSingleSwap} when `getSwapStatus` throws
+     * {@link SwapNotFoundError}. The threshold rides out a transient blip
+     * but ensures we stop hammering Boltz with requests for swap IDs the
+     * server has no record of (e.g. after switching the configured
+     * Boltz endpoint).
+     */
+    private async handleSwapNotFound(swap: BoltzSwap): Promise<void> {
+        const count = (this.notFoundCounts.get(swap.id) ?? 0) + 1;
+        this.notFoundCounts.set(swap.id, count);
+        logger.warn(
+            `Swap ${swap.id}: unknown to Boltz (${count}/${SwapManager.NOT_FOUND_THRESHOLD} consecutive)`
+        );
+        if (count >= SwapManager.NOT_FOUND_THRESHOLD) {
+            await this.markSwapAsUnknownToProvider(swap);
+        }
+    }
+
+    /**
+     * Transition a swap to {@code swap.expired} (terminal for all swap types)
+     * after Boltz has consistently reported it unknown for
+     * {@link SwapManager.NOT_FOUND_THRESHOLD} consecutive polls. The swap is
+     * persisted, removed from monitoring, and reported via `onSwapFailed`.
+     * Bypasses {@link handleSwapStatusUpdate} on purpose: we don't want to
+     * trigger autonomous claim/refund actions against a Boltz instance that
+     * has no record of this swap — the requests would just generate more
+     * 404s without recovering anything.
+     */
+    private async markSwapAsUnknownToProvider(swap: BoltzSwap): Promise<void> {
+        // Idempotency: bail if a concurrent path already removed the swap.
+        if (!this.monitoredSwaps.has(swap.id)) {
+            this.notFoundCounts.delete(swap.id);
+            return;
+        }
+
+        // Remove from monitoring first so any in-flight poll/WS handler
+        // for this ID becomes a no-op.
+        this.monitoredSwaps.delete(swap.id);
+        this.swapSubscriptions.delete(swap.id);
+        const retryTimer = this.pollRetryTimers.get(swap.id);
+        if (retryTimer) {
+            clearTimeout(retryTimer);
+            this.pollRetryTimers.delete(swap.id);
+        }
+        this.notFoundCounts.delete(swap.id);
+
+        // `swap.expired` is final for submarine, reverse, and chain swaps
+        // (see is*FinalStatus helpers). On next start the swap is loaded
+        // with a final status and won't be re-added to monitoredSwaps.
+        swap.status = "swap.expired";
+
+        const error = new SwapNotFoundError(swap.id);
+        try {
+            await this.saveSwap(swap);
+        } catch (saveError) {
+            logger.error(
+                `Failed to persist unknown-to-provider state for swap ${swap.id}:`,
+                saveError
+            );
+        }
+
+        logger.warn(
+            `Swap ${swap.id}: marked failed after ${SwapManager.NOT_FOUND_THRESHOLD} consecutive Boltz 404s — swap is unknown to the configured Boltz instance`
+        );
+
+        this.swapFailedListeners.forEach((listener) => listener(swap, error));
     }
 
     /**

--- a/test/boltz-swap-provider.test.ts
+++ b/test/boltz-swap-provider.test.ts
@@ -309,7 +309,9 @@ describe("BoltzSwapProvider", () => {
                         ok: false,
                         status: 404,
                         text: () =>
-                            Promise.resolve("<html><body>Not Found</body></html>"),
+                            Promise.resolve(
+                                "<html><body>Not Found</body></html>"
+                            ),
                         headers: { get: () => null },
                     })
                 )

--- a/test/boltz-swap-provider.test.ts
+++ b/test/boltz-swap-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { BoltzSwapProvider } from "../src/boltz-swap-provider";
-import { SchemaError, NetworkError } from "../src/errors";
+import { SchemaError, NetworkError, SwapNotFoundError } from "../src/errors";
 import {
     extractInvoiceAmount,
     extractTimeLockFromLeafOutput,
@@ -264,6 +264,65 @@ describe("BoltzSwapProvider", () => {
             await expect(provider.getSwapStatus("mock-id")).rejects.toThrow(
                 SchemaError
             );
+        });
+
+        it("should throw SwapNotFoundError on 404 with 'could not find swap' body", async () => {
+            // Boltz returns this shape when the configured instance has no
+            // record of the swap — typically after the operator switched
+            // the API URL to a different Boltz instance.
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(() =>
+                    Promise.resolve({
+                        ok: false,
+                        status: 404,
+                        text: () =>
+                            Promise.resolve(
+                                JSON.stringify({
+                                    error: "could not find swap with id: mock-id",
+                                })
+                            ),
+                        headers: { get: () => null },
+                    })
+                )
+            );
+
+            try {
+                await provider.getSwapStatus("mock-id");
+                expect.fail("Should have thrown SwapNotFoundError");
+            } catch (error) {
+                expect(error).toBeInstanceOf(SwapNotFoundError);
+                expect(error).toBeInstanceOf(NetworkError);
+                expect((error as SwapNotFoundError).swapId).toBe("mock-id");
+                expect((error as SwapNotFoundError).statusCode).toBe(404);
+            }
+        });
+
+        it("should throw plain NetworkError on 404 from a renamed route or proxy", async () => {
+            // A 404 from a misconfigured proxy or a renamed route must NOT
+            // trip the safety net — the SwapManager counter only increments
+            // on the explicit "could not find swap" body.
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(() =>
+                    Promise.resolve({
+                        ok: false,
+                        status: 404,
+                        text: () =>
+                            Promise.resolve("<html><body>Not Found</body></html>"),
+                        headers: { get: () => null },
+                    })
+                )
+            );
+
+            try {
+                await provider.getSwapStatus("mock-id");
+                expect.fail("Should have thrown NetworkError");
+            } catch (error) {
+                expect(error).toBeInstanceOf(NetworkError);
+                expect(error).not.toBeInstanceOf(SwapNotFoundError);
+                expect((error as NetworkError).statusCode).toBe(404);
+            }
         });
     });
 

--- a/test/swap-manager.test.ts
+++ b/test/swap-manager.test.ts
@@ -1335,6 +1335,52 @@ describe("SwapManager", () => {
             expect(onSwapFailed).not.toHaveBeenCalled();
         });
 
+        it("settles waitForSwapCompletion when the safety net trips", async () => {
+            // Regression: markSwapAsUnknownToProvider used to delete the
+            // per-swap subscriber set before emitting anything. Awaiters
+            // registered via subscribeToSwapUpdates (waitForSwapCompletion,
+            // waitAndClaim*, etc.) would hang forever after the trip.
+            const saveSwap = vi.fn().mockResolvedValue(undefined);
+            swapManager.setCallbacks(makeCallbacks({ saveSwap }));
+
+            const swap = {
+                ...mockSubmarineSwap,
+                status: "invoice.set" as const,
+            };
+            await swapManager.start([swap]);
+
+            const completion = swapManager.waitForSwapCompletion(swap.id);
+
+            stubSwapNotFound();
+            for (let i = 0; i < NOT_FOUND_THRESHOLD; i++) {
+                await (swapManager as any).pollAllSwaps();
+            }
+
+            await expect(completion).rejects.toThrow(/swap\.expired/);
+        });
+
+        it("notifies per-swap subscribers with the terminal status", async () => {
+            const saveSwap = vi.fn().mockResolvedValue(undefined);
+            swapManager.setCallbacks(makeCallbacks({ saveSwap }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            const subscriber = vi.fn();
+            await swapManager.subscribeToSwapUpdates(swap.id, subscriber);
+
+            stubSwapNotFound();
+            for (let i = 0; i < NOT_FOUND_THRESHOLD; i++) {
+                await (swapManager as any).pollAllSwaps();
+            }
+
+            expect(subscriber).toHaveBeenCalledTimes(1);
+            const [updatedSwap, oldStatus] = subscriber.mock.calls[0];
+            expect(updatedSwap.id).toBe(swap.id);
+            expect(updatedSwap.status).toBe("swap.expired");
+            expect(oldStatus).toBe("swap.created");
+        });
+
         it("resets counter on a successful poll", async () => {
             const onSwapFailed = vi.fn();
             const saveSwap = vi.fn().mockResolvedValue(undefined);

--- a/test/swap-manager.test.ts
+++ b/test/swap-manager.test.ts
@@ -1363,7 +1363,10 @@ describe("SwapManager", () => {
             const saveSwap = vi.fn().mockResolvedValue(undefined);
             swapManager.setCallbacks(makeCallbacks({ saveSwap }));
 
-            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            const swap = {
+                ...mockReverseSwap,
+                status: "swap.created" as const,
+            };
             await swapManager.start([swap]);
 
             const subscriber = vi.fn();

--- a/test/swap-manager.test.ts
+++ b/test/swap-manager.test.ts
@@ -1281,7 +1281,10 @@ describe("SwapManager", () => {
             swapManager.setCallbacks(makeCallbacks({ saveSwap }));
             await swapManager.onSwapFailed(onSwapFailed);
 
-            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            const swap = {
+                ...mockReverseSwap,
+                status: "swap.created" as const,
+            };
             await swapManager.start([swap]);
 
             stubSwapNotFound();
@@ -1314,7 +1317,10 @@ describe("SwapManager", () => {
             swapManager.setCallbacks(makeCallbacks({ saveSwap }));
             await swapManager.onSwapFailed(onSwapFailed);
 
-            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            const swap = {
+                ...mockReverseSwap,
+                status: "swap.created" as const,
+            };
             await swapManager.start([swap]);
 
             stubSwapNotFound();
@@ -1335,7 +1341,10 @@ describe("SwapManager", () => {
             swapManager.setCallbacks(makeCallbacks({ saveSwap }));
             await swapManager.onSwapFailed(onSwapFailed);
 
-            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            const swap = {
+                ...mockReverseSwap,
+                status: "swap.created" as const,
+            };
             await swapManager.start([swap]);
 
             // 9 consecutive 404s.

--- a/test/swap-manager.test.ts
+++ b/test/swap-manager.test.ts
@@ -1229,4 +1229,135 @@ describe("SwapManager", () => {
             expect(stats2.websocketConnected).toBe(true);
         });
     });
+
+    /**
+     * Safety net for swaps that have become unknown to the configured Boltz
+     * instance — typically because the operator switched the API URL to a
+     * different Boltz instance. Without it, the polling loop would 404 on
+     * every interval forever, generating server load and log noise. After
+     * 10 consecutive `getSwapStatus` 404s the swap is transitioned to
+     * `swap.expired` (terminal) and dropped from monitoring.
+     */
+    describe("Unknown to Boltz (404 safety net)", () => {
+        const NOT_FOUND_THRESHOLD = 10;
+
+        function stubSwapNotFound() {
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 404,
+                    text: () =>
+                        Promise.resolve(
+                            JSON.stringify({
+                                error: "could not find swap with id: any",
+                            })
+                        ),
+                    headers: { get: () => null },
+                } as unknown as Response)
+            );
+        }
+
+        function stubSwapStatusOk(status = "swap.created") {
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ status }),
+                    headers: new Headers({ "content-length": "100" }),
+                } as Response)
+            );
+        }
+
+        beforeEach(() => {
+            swapManager = new SwapManager(swapProvider, {
+                ...swapManagerConfig,
+                enableAutoActions: false, // we don't want auto refund/claim noise here
+            });
+            swapManager.setCallbacks(makeCallbacks());
+        });
+
+        it("trips after threshold, persists swap.expired, removes from monitoring, fires onSwapFailed", async () => {
+            const onSwapFailed = vi.fn();
+            const saveSwap = vi.fn().mockResolvedValue(undefined);
+            swapManager.setCallbacks(makeCallbacks({ saveSwap }));
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            stubSwapNotFound();
+
+            // Drive `pollAllSwaps` exactly THRESHOLD times. Each call should
+            // increment the counter; the THRESHOLD-th call trips the safety
+            // net and removes the swap.
+            for (let i = 0; i < NOT_FOUND_THRESHOLD; i++) {
+                await (swapManager as any).pollAllSwaps();
+            }
+
+            const stats = await swapManager.getStats();
+            expect(stats.monitoredSwaps).toBe(0);
+
+            expect(saveSwap).toHaveBeenCalled();
+            const persisted = saveSwap.mock.calls.at(-1)![0];
+            expect(persisted.id).toBe(swap.id);
+            expect(persisted.status).toBe("swap.expired");
+
+            expect(onSwapFailed).toHaveBeenCalledTimes(1);
+            const [failedSwap, failedError] = onSwapFailed.mock.calls[0];
+            expect(failedSwap.id).toBe(swap.id);
+            expect(failedError.name).toBe("SwapNotFoundError");
+            expect(failedError.swapId).toBe(swap.id);
+        });
+
+        it("does not trip below threshold", async () => {
+            const onSwapFailed = vi.fn();
+            const saveSwap = vi.fn().mockResolvedValue(undefined);
+            swapManager.setCallbacks(makeCallbacks({ saveSwap }));
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            stubSwapNotFound();
+
+            for (let i = 0; i < NOT_FOUND_THRESHOLD - 1; i++) {
+                await (swapManager as any).pollAllSwaps();
+            }
+
+            const stats = await swapManager.getStats();
+            expect(stats.monitoredSwaps).toBe(1);
+            expect(saveSwap).not.toHaveBeenCalled();
+            expect(onSwapFailed).not.toHaveBeenCalled();
+        });
+
+        it("resets counter on a successful poll", async () => {
+            const onSwapFailed = vi.fn();
+            const saveSwap = vi.fn().mockResolvedValue(undefined);
+            swapManager.setCallbacks(makeCallbacks({ saveSwap }));
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            // 9 consecutive 404s.
+            stubSwapNotFound();
+            for (let i = 0; i < NOT_FOUND_THRESHOLD - 1; i++) {
+                await (swapManager as any).pollAllSwaps();
+            }
+
+            // One successful poll should clear the counter — no status change
+            // here so the swap is not promoted, but the counter resets.
+            stubSwapStatusOk("swap.created");
+            await (swapManager as any).pollAllSwaps();
+
+            // Now back to 404. With the counter reset, a single 404 must NOT
+            // trip the safety net.
+            stubSwapNotFound();
+            await (swapManager as any).pollAllSwaps();
+
+            const stats = await swapManager.getStats();
+            expect(stats.monitoredSwaps).toBe(1);
+            expect(saveSwap).not.toHaveBeenCalled();
+            expect(onSwapFailed).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION

- Update production endpoint
- Stop polling swaps unknown to Boltz after 10 consecutive 404s (mimic https://github.com/arkade-os/dotnet-sdk/pull/80)