### PR TITLE
[ArkadeScript] Offline receive via arkade script solver

### DIFF
--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -38,6 +38,7 @@ import type {
     SendLightningPaymentResponse,
     ArkToBtcResponse,
     BtcToArkResponse,
+    OfflineReceiveOptions,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
     SubmarineRefundOutcome,
@@ -100,6 +101,11 @@ import {
     refundVHTLCwithOffchainTx,
     type VhtlcTimeouts,
 } from "./utils/vhtlc";
+import {
+    computeArkadeScriptPubkey,
+    enforcePayTo,
+    registerOfflineReceive,
+} from "./utils/offline-receive";
 
 type SubmarineVHTLCDiagnostic = {
     totalVtxoCount: number;
@@ -477,9 +483,20 @@ export class ArkadeSwaps {
         if (args.amount <= 0)
             throw new SwapError({ message: "Amount must be greater than 0" });
 
-        const claimPublicKey = hex.encode(
-            await this.wallet.identity.compressedPublicKey()
-        );
+        const arkadeScript = args.offlineReceive
+            ? enforcePayTo(
+                  ArkAddress.decode(await this.wallet.getAddress()).pkScript
+              )
+            : undefined;
+        const claimPublicKey = arkadeScript
+            ? "02" +
+              hex.encode(
+                  computeArkadeScriptPubkey(
+                      hex.decode(args.offlineReceive!.introspectorPubkey),
+                      arkadeScript
+                  )
+              )
+            : hex.encode(await this.wallet.identity.compressedPublicKey());
         if (!claimPublicKey)
             throw new SwapError({
                 message: "Failed to get claim public key from wallet",
@@ -514,6 +531,24 @@ export class ArkadeSwaps {
             response: swapResponse,
             status: "swap.created",
         };
+
+        if (args.offlineReceive && arkadeScript) {
+            const arkInfo = await this.arkProvider.getInfo();
+            const { vhtlcScript } = this.createVHTLCScript({
+                network: arkInfo.network,
+                preimageHash: sha256(preimage),
+                receiverPubkey: claimPublicKey,
+                senderPubkey: swapResponse.refundPublicKey!,
+                serverPubkey: arkInfo.signerPubkey,
+                timeoutBlockHeights: swapResponse.timeoutBlockHeights!,
+            });
+            await registerOfflineReceive(
+                args.offlineReceive.bancodUrl,
+                preimage,
+                arkadeScript,
+                vhtlcScript.scripts.map((s) => hex.encode(s))
+            );
+        }
 
         // save pending swap to storage
         await this.savePendingReverseSwap(pendingSwap);
@@ -1966,6 +2001,7 @@ export class ArkadeSwaps {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     }): Promise<BtcToArkResponse> {
         const pendingSwap = await this.createChainSwap({
             to: "ARK",
@@ -1974,6 +2010,7 @@ export class ArkadeSwaps {
             senderLockAmount: args.senderLockAmount,
             receiverLockAmount: args.receiverLockAmount,
             toAddress: await this.wallet.getAddress(),
+            offlineReceive: args.offlineReceive,
         });
 
         await this.verifyChainSwap({
@@ -2322,6 +2359,7 @@ export class ArkadeSwaps {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     }): Promise<BoltzChainSwap> {
         const { to, from, receiverLockAmount, senderLockAmount, toAddress } =
             args;
@@ -2369,10 +2407,23 @@ export class ArkadeSwaps {
                 message: "Failed to get refund public key",
             });
 
-        const claimPublicKey =
-            to === "ARK"
-                ? hex.encode(await this.wallet.identity.compressedPublicKey())
-                : hex.encode(secp256k1.getPublicKey(ephemeralKey));
+        const offlineArkadeScript =
+            args.offlineReceive && to === "ARK"
+                ? enforcePayTo(
+                      ArkAddress.decode(await this.wallet.getAddress()).pkScript
+                  )
+                : undefined;
+        const claimPublicKey = offlineArkadeScript
+            ? "02" +
+              hex.encode(
+                  computeArkadeScriptPubkey(
+                      hex.decode(args.offlineReceive!.introspectorPubkey),
+                      offlineArkadeScript
+                  )
+              )
+            : to === "ARK"
+              ? hex.encode(await this.wallet.identity.compressedPublicKey())
+              : hex.encode(secp256k1.getPublicKey(ephemeralKey));
 
         if (!claimPublicKey)
             throw new SwapError({
@@ -2406,6 +2457,24 @@ export class ArkadeSwaps {
             toAddress: args.toAddress,
             type: "chain",
         };
+
+        if (args.offlineReceive && offlineArkadeScript) {
+            const arkInfo = await this.arkProvider.getInfo();
+            const { vhtlcScript } = this.createVHTLCScript({
+                network: arkInfo.network,
+                preimageHash: sha256(preimage),
+                receiverPubkey: claimPublicKey,
+                senderPubkey: swapResponse.claimDetails.serverPublicKey,
+                serverPubkey: arkInfo.signerPubkey,
+                timeoutBlockHeights: swapResponse.claimDetails.timeouts!,
+            });
+            await registerOfflineReceive(
+                args.offlineReceive.bancodUrl,
+                preimage,
+                offlineArkadeScript,
+                vhtlcScript.scripts.map((s) => hex.encode(s))
+            );
+        }
 
         await this.savePendingChainSwap(pendingSwap);
 

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -3036,6 +3036,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     }): Promise<BtcToArkResponse>;
     waitAndClaimArk(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
     claimArk(pendingSwap: BoltzChainSwap): Promise<void>;
@@ -3048,6 +3049,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     }): Promise<BoltzChainSwap>;
     verifyChainSwap(args: {
         to: Chain;

--- a/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -26,6 +26,7 @@ import {
     BoltzChainSwap,
     BoltzReverseSwap,
     BoltzSubmarineSwap,
+    type OfflineReceiveOptions,
     type SendLightningPaymentRequest,
     SendLightningPaymentResponse,
     type SubmarineRecoveryInfo,
@@ -288,6 +289,7 @@ export type RequestBtcToArk = RequestEnvelope & {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     };
 };
 export type ResponseBtcToArk = ResponseEnvelope & {
@@ -304,6 +306,7 @@ export type RequestCreateChainSwap = RequestEnvelope & {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     };
 };
 export type ResponseCreateChainSwap = ResponseEnvelope & {

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -13,6 +13,7 @@ import {
     BoltzChainSwap,
     BoltzReverseSwap,
     BoltzSubmarineSwap,
+    OfflineReceiveOptions,
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
     SubmarineRecoveryInfo,
@@ -668,6 +669,7 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     }): Promise<BtcToArkResponse> {
         try {
             const res = await this.sendMessage({
@@ -691,6 +693,7 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         feeSatsPerByte?: number;
         senderLockAmount?: number;
         receiverLockAmount?: number;
+        offlineReceive?: OfflineReceiveOptions;
     }): Promise<BoltzChainSwap> {
         try {
             const res = await this.sendMessage({

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,14 @@ import {
 import { SwapManagerConfig } from "./swap-manager";
 import { SwapRepository } from "./repositories/swap-repository";
 
+/** Options for delegating VHTLC claiming to a bancod solver. */
+export type OfflineReceiveOptions = {
+    /** Base URL of the bancod HTTP gateway (e.g. "http://localhost:7091"). */
+    bancodUrl: string;
+    /** Hex-encoded compressed or x-only introspector signer pubkey. */
+    introspectorPubkey: string;
+};
+
 /** A virtual transaction output (VTXO) — an off-chain UTXO in the Ark protocol. */
 // TODO: replace with better data structure
 export interface Vtxo {
@@ -71,6 +79,8 @@ export interface CreateLightningInvoiceRequest {
     amount: number;
     /** Optional description embedded in the BOLT11 invoice. */
     description?: string;
+    /** When set, the VHTLC is claimable by a bancod preimage solver instead of the wallet. */
+    offlineReceive?: OfflineReceiveOptions;
 }
 
 /** Response containing the created Lightning invoice and swap details. */

--- a/src/utils/offline-receive.ts
+++ b/src/utils/offline-receive.ts
@@ -1,0 +1,72 @@
+import { hex } from "@scure/base";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
+
+// Arkade enforcement script pinning output[currentInputIndex] to the given
+// P2TR pkScript with value >= input value. Layout:
+//   OP_PUSHCURRENTINPUTINDEX OP_DUP OP_INSPECTOUTPUTSCRIPTPUBKEY
+//   OP_1 OP_EQUALVERIFY <witnessProgram> OP_EQUALVERIFY
+//   OP_INSPECTOUTPUTVALUE OP_PUSHCURRENTINPUTINDEX OP_INSPECTINPUTVALUE
+//   OP_GREATERTHANOREQUAL
+export function enforcePayTo(p2tr: Uint8Array): Uint8Array {
+    if (p2tr.length !== 34 || p2tr[0] !== 0x51 || p2tr[1] !== 0x20) {
+        throw new Error("offlineReceive: expected v1 P2TR pkScript");
+    }
+    return new Uint8Array([
+        0xcd, // OP_PUSHCURRENTINPUTINDEX
+        0x76, // OP_DUP
+        0xd1, // OP_INSPECTOUTPUTSCRIPTPUBKEY
+        0x51, // OP_1
+        0x88, // OP_EQUALVERIFY
+        0x20, // OP_DATA_32
+        ...p2tr.slice(2),
+        0x88, // OP_EQUALVERIFY
+        0xcf, // OP_INSPECTOUTPUTVALUE
+        0xcd, // OP_PUSHCURRENTINPUTINDEX
+        0xc9, // OP_INSPECTINPUTVALUE
+        0xa2, // OP_GREATERTHANOREQUAL
+    ]);
+}
+
+export function computeArkadeScriptPubkey(
+    introPubkey: Uint8Array,
+    script: Uint8Array
+): Uint8Array {
+    const tag = schnorr.utils.taggedHash("ArkScriptHash", script);
+    const xOnly =
+        introPubkey.length === 33 ? introPubkey.subarray(1) : introPubkey;
+    const point = secp256k1.Point.fromHex("02" + hex.encode(xOnly));
+    let scalar = 0n;
+    for (const b of tag) scalar = (scalar << 8n) | BigInt(b);
+    scalar = scalar % secp256k1.Point.CURVE().n || 1n;
+    const tweak = secp256k1.Point.BASE.multiply(scalar);
+    return point.add(tweak).toBytes().subarray(1);
+}
+
+export async function registerOfflineReceive(
+    bancodUrl: string,
+    preimage: Uint8Array,
+    arkadeScript: Uint8Array,
+    taptree: string[]
+): Promise<string> {
+    const toB64 = (b: Uint8Array) => Buffer.from(b).toString("base64");
+    const r = await fetch(`${bancodUrl}/v1/preimage/claim`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+            preimage: toB64(preimage),
+            arkade_script: toB64(arkadeScript),
+            taptree,
+        }),
+    });
+    if (!r.ok) {
+        throw new Error(
+            `bancod register failed: ${r.status} ${await r.text()}`
+        );
+    }
+    const body = (await r.json()) as Record<string, string>;
+    const claimAddress = body.claimAddress ?? body.claim_address;
+    if (!claimAddress) {
+        throw new Error(`bancod register: missing claim_address in response`);
+    }
+    return claimAddress;
+}

--- a/src/utils/offline-receive.ts
+++ b/src/utils/offline-receive.ts
@@ -1,4 +1,4 @@
-import { hex } from "@scure/base";
+import { base64, hex } from "@scure/base";
 import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 
 // Arkade enforcement script pinning output[currentInputIndex] to the given
@@ -48,13 +48,12 @@ export async function registerOfflineReceive(
     arkadeScript: Uint8Array,
     taptree: string[]
 ): Promise<string> {
-    const toB64 = (b: Uint8Array) => Buffer.from(b).toString("base64");
     const r = await fetch(`${bancodUrl}/v1/preimage/claim`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-            preimage: toB64(preimage),
-            arkade_script: toB64(arkadeScript),
+            preimage: base64.encode(preimage),
+            arkade_script: base64.encode(arkadeScript),
             taptree,
         }),
     });

--- a/test/e2e/arkade-swaps.test.ts
+++ b/test/e2e/arkade-swaps.test.ts
@@ -22,7 +22,7 @@ import {
     InMemoryContractRepository,
 } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
-import { schnorr } from "@noble/curves/secp256k1.js";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 import { decodeInvoice } from "../../src/utils/decoding";
 import { pubECDSA, sha256 } from "@scure/btc-signer/utils.js";
 import { exec } from "child_process";
@@ -32,6 +32,18 @@ const execAsync = promisify(exec);
 const lncli = "docker exec -i lnd lncli --network=regtest";
 const bccli = "docker exec -t bitcoin bitcoin-cli -regtest";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const offlineReceive = {
+    bancodUrl: "http://localhost:7091",
+    introspectorPubkey: hex.encode(
+        secp256k1.getPublicKey(
+            hex.decode(
+                "5646b2e23bbb82491fb4ef262079ff17594d5e873fc6bcea5f1453edbe1029b1"
+            ),
+            true
+        )
+    ),
+};
 
 const createWalletStorage = () => ({
     walletRepository: new InMemoryWalletRepository(),
@@ -522,6 +534,35 @@ describe("ArkadeSwaps", () => {
 
                     await swaps.waitAndClaim(pendingSwap);
                     await sleep(2000);
+                    const balanceAfter = await wallet.getBalance();
+                    expect(balanceAfter.available).toBeGreaterThan(
+                        balanceBefore.available
+                    );
+                }
+            );
+
+            it(
+                "should increase balance when invoice is paid (offlineReceive via bancod)",
+                { timeout: 30_000 },
+                async () => {
+                    const amount = 1000;
+                    const balanceBefore = await wallet.getBalance();
+                    const pendingSwap = await swaps.createReverseSwap({
+                        amount,
+                        offlineReceive,
+                    });
+
+                    sleep(1000).then(() =>
+                        payInvoice(pendingSwap.response.invoice).catch((err) =>
+                            console.error("Error paying invoice:", err)
+                        )
+                    );
+
+                    await waitForBalance(
+                        () => wallet.getBalance(),
+                        balanceBefore.available + 1,
+                        25_000
+                    );
                     const balanceAfter = await wallet.getBalance();
                     expect(balanceAfter.available).toBeGreaterThan(
                         balanceBefore.available
@@ -1208,6 +1249,27 @@ describe("ArkadeSwaps", () => {
                     await fundBtcAddress(btcAddress, amountToPay);
                     await swaps.waitAndClaimArk(pendingSwap);
 
+                    const balance = await wallet.getBalance();
+                    expect(balance.available).toEqual(amountSats);
+                }
+            );
+
+            it(
+                "should perform Btc to Ark chain swap successfully (offlineReceive via bancod)",
+                { timeout: 30_000 },
+                async () => {
+                    const amountSats = 21000;
+                    const { btcAddress, amountToPay } = await swaps.btcToArk({
+                        receiverLockAmount: amountSats,
+                        offlineReceive,
+                    });
+
+                    await fundBtcAddress(btcAddress, amountToPay);
+                    await waitForBalance(
+                        () => wallet.getBalance(),
+                        amountSats,
+                        25_000
+                    );
                     const balance = await wallet.getBalance();
                     expect(balance.available).toEqual(amountSats);
                 }

--- a/test/e2e/docker-compose.bancod.yml
+++ b/test/e2e/docker-compose.bancod.yml
@@ -1,0 +1,43 @@
+name: nigiri
+services:
+    introspector:
+        image: ghcr.io/arklabshq/introspector:v0.0.1
+        container_name: introspector
+        restart: unless-stopped
+        environment:
+            - INTROSPECTOR_SECRET_KEY=5646b2e23bbb82491fb4ef262079ff17594d5e873fc6bcea5f1453edbe1029b1
+            - INTROSPECTOR_NO_TLS=true
+            - INTROSPECTOR_LOG_LEVEL=5
+            - INTROSPECTOR_ARKD_URL=arkd:7070
+        ports:
+            - 7173:7073
+        volumes:
+            - type: tmpfs
+              target: /app/data
+
+    bancod:
+        image: ghcr.io/arkade-os/bancod:v0.0.1-rc.2
+        container_name: bancod
+        restart: unless-stopped
+        depends_on:
+            - introspector
+        environment:
+            - BANCOD_ARK_URL=arkd:7070
+            - BANCOD_INTROSPECTOR_URL=introspector:7073
+            - BANCOD_WALLET_SEED=4242424242424242424242424242424242424242424242424242424242424242
+            - BANCOD_WALLET_PASSWORD=password
+            - BANCOD_BANCO_ENABLED=false
+            - BANCOD_PREIMAGE_ENABLED=true
+            - BANCOD_DATADIR=/app/data
+            - BANCOD_LOG_LEVEL=5
+        ports:
+            - 7090:7070
+            - 7091:7071
+        volumes:
+            - type: tmpfs
+              target: /app/data
+
+networks:
+    default:
+        name: nigiri
+        external: true

--- a/test/e2e/setup.mjs
+++ b/test/e2e/setup.mjs
@@ -1,8 +1,11 @@
 import { promisify } from "util";
 import { setTimeout } from "timers";
 import { execSync } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
 
 const sleep = promisify(setTimeout);
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 async function waitForArkServer(maxRetries = 30, retryDelay = 2000) {
     console.log("Waiting for ark server to be ready...");
@@ -46,12 +49,33 @@ async function waitForBoltzPairs(maxRetries = 30, retryDelay = 2000) {
     throw new Error("Boltz ARK/BTC pairs not available after maximum retries");
 }
 
+async function startBancod() {
+    console.log("Starting bancod preimage solver...");
+    execSync(
+        `docker compose -f ${resolve(HERE, "docker-compose.bancod.yml")} up -d`,
+        { stdio: "inherit" }
+    );
+    for (let i = 0; i < 30; i++) {
+        try {
+            execSync("curl -sf http://localhost:7091/v1/preimage/claims", {
+                stdio: "pipe",
+            });
+            console.log("  ✔ bancod ready");
+            return;
+        } catch {
+            await sleep(2000);
+        }
+    }
+    throw new Error("bancod failed to be ready after maximum retries");
+}
+
 // Run setup — arkade-regtest handles all infrastructure.
 // This script just waits for services to be ready.
 async function setup() {
     try {
         await waitForArkServer();
         await waitForBoltzPairs();
+        await startBancod();
         console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         console.log("  ✓ regtest setup completed successfully");
         console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");


### PR DESCRIPTION
The idea behind the "offline receive" feature is to delegate the preimage reveal (claim) to a third party. in our case, that third party is an arkade script **solver** (bancod: https://github.com/arkade-os/bancod). it is responsible of storing preimages and then craft and broadcast the claim transactions. This behavior is programmed inside an arkade script covenant = an introspector tweaked public key : `Introspector + ArkadeScript(covenant)`.

Using this public key as the "claimPubKey" while building VHTLC allows to delegate the claim step to the solver.

1. Receiver generate invoice
2. Receiver shares preimge+swapAddress to Solver using a public API
3. Sender pays the invoice
4. Solver claims the VHTLC using the preimage
5. Receiver comes back 6 months later : htlc is claimed ! 

@Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline-receive support for chain and reverse swaps so users can claim funds via an external Bancod-backed offline flow.
  * Swap APIs and request payloads accept an offlineReceive option to enable the offline claim flow.

* **Tests**
  * End-to-end tests covering offlineReceive flows for both BTC→ARK and Lightning→ARK.

* **Chores**
  * Added a local Bancod test environment and startup to the e2e setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->