### PR TITLE
Add default referral ID if not included

### DIFF
--- a/src/boltz-swap-provider.ts
+++ b/src/boltz-swap-provider.ts
@@ -1035,7 +1035,7 @@ export class BoltzSwapProvider {
     /** @param config Provider configuration with network and optional API URL. */
     constructor(config: SwapProviderConfig) {
         this.network = config.network;
-        this.referralId = config.referralId;
+        this.referralId = config.referralId ?? "arkade-ts-sdk";
         const apiUrl = config.apiUrl || BASE_URLS[config.network];
         if (!apiUrl)
             throw new Error(

--- a/test/boltz-swap-provider.test.ts
+++ b/test/boltz-swap-provider.test.ts
@@ -439,6 +439,7 @@ describe("BoltzSwapProvider", () => {
                         to: "BTC",
                         invoice,
                         refundPublicKey: mockHexCompressedPubKey,
+                        referralId: "arkade-ts-sdk",
                     }),
                 }
             );
@@ -501,6 +502,7 @@ describe("BoltzSwapProvider", () => {
                         claimPublicKey: mockHexCompressedPubKey,
                         preimageHash: "mock-preimage-hash",
                         description: "Send to Arkade address",
+                        referralId: "arkade-ts-sdk",
                     }),
                 }
             );
@@ -547,6 +549,7 @@ describe("BoltzSwapProvider", () => {
                         claimPublicKey: mockHexCompressedPubKey,
                         preimageHash: "mock-preimage-hash",
                         description: "Test payment for coffee",
+                        referralId: "arkade-ts-sdk",
                     }),
                 }
             );
@@ -593,6 +596,7 @@ describe("BoltzSwapProvider", () => {
                         claimPublicKey: mockHexCompressedPubKey,
                         preimageHash: "mock-preimage-hash",
                         description: "Send to Arkade address",
+                        referralId: "arkade-ts-sdk",
                         // description should be replaced with default
                     }),
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where swap operations were not including referral information by default. Referral tracking is now automatically included in swap requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->