### PR TITLE
Recover from half-initialized ArkadeSwaps handler after SW restart

### DIFF
--- a/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -43,6 +43,15 @@ import type { SwapManagerClient } from "../swap-manager";
 
 export const DEFAULT_MESSAGE_TAG = "ARKADE_SWAPS_UPDATER";
 
+export const HANDLER_NOT_INITIALIZED = "ArkadeSwaps handler not initialized";
+
+export class HandlerNotInitializedError extends Error {
+    constructor() {
+        super(HANDLER_NOT_INITIALIZED);
+        this.name = "HandlerNotInitializedError";
+    }
+}
+
 export type RequestInitArkSwaps = RequestEnvelope & {
     type: "INIT_ARKADE_SWAPS";
     payload: Omit<
@@ -742,7 +751,7 @@ export class ArkadeSwapsMessageHandler
         if (!this.handler || !this.wallet) {
             return this.tagged({
                 id,
-                error: new Error("handler not initialized"),
+                error: new HandlerNotInitializedError(),
             });
         }
 

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -24,6 +24,7 @@ import {
     ArkadeSwapsUpdaterRequest,
     ArkadeSwapsUpdaterResponse,
     DEFAULT_MESSAGE_TAG,
+    HANDLER_NOT_INITIALIZED,
     RequestInitArkSwaps,
     LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES,
 } from "./arkade-swaps-message-handler";
@@ -81,6 +82,17 @@ function isMessageBusNotInitializedError(error: unknown): boolean {
     return (
         error instanceof Error &&
         error.message.includes(MESSAGE_BUS_NOT_INITIALIZED)
+    );
+}
+
+// Same structured-clone caveat as above: match by message string. Triggered
+// when the bus has been re-initialized (e.g. by the wallet's restart-recovery
+// path) but the ArkadeSwaps handler's own init payload has not been re-sent,
+// leaving `handler.handler` undefined. Reinitialize from cached initPayload.
+function isHandlerNotInitializedError(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        error.message.includes(HANDLER_NOT_INITIALIZED)
     );
 }
 
@@ -1154,10 +1166,10 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
             try {
                 return await this.sendMessageDirect(request, timeoutMs);
             } catch (error: any) {
-                if (
-                    !isMessageBusNotInitializedError(error) ||
-                    attempt >= maxRetries
-                ) {
+                const recoverable =
+                    isMessageBusNotInitializedError(error) ||
+                    isHandlerNotInitializedError(error);
+                if (!recoverable || attempt >= maxRetries) {
                     throw error;
                 }
 

--- a/test/serviceWorker/arkade-swaps-runtime.test.ts
+++ b/test/serviceWorker/arkade-swaps-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ServiceWorkerArkadeSwaps } from "../../src/serviceWorker/arkade-swaps-runtime";
 import {
     DEFAULT_MESSAGE_TAG,
+    HANDLER_NOT_INITIALIZED,
     type RequestInitArkSwaps,
 } from "../../src/serviceWorker/arkade-swaps-message-handler";
 import type { BoltzReverseSwap, BoltzSubmarineSwap } from "../../src/types";
@@ -412,6 +413,58 @@ describe("sendMessage reinitialize on SW restart", () => {
         expect(serviceWorker.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({ type: "INIT_ARKADE_SWAPS" })
         );
+    });
+
+    it("retries after re-initializing when SW returns 'ArkadeSwaps handler not initialized'", async () => {
+        // Simulates the wallet-driven bus reinit gap: the bus has been
+        // re-initialized after a SW restart (so PING/PONG works and routing
+        // happens), but the page-side ArkadeSwaps init payload has not been
+        // re-sent yet, so handler.handler is undefined and handleMessage
+        // returns HANDLER_NOT_INITIALIZED for any non-INIT request.
+        let handlerInitialized = false;
+        const { navigatorServiceWorker, serviceWorker } =
+            createServiceWorkerHarness((message) => {
+                if (message.type === "INIT_ARKADE_SWAPS") {
+                    handlerInitialized = true;
+                    return {
+                        id: message.id,
+                        tag: TAG,
+                        type: "ARKADE_SWAPS_INITIALIZED",
+                    };
+                }
+                if (!handlerInitialized) {
+                    return {
+                        id: message.id,
+                        tag: TAG,
+                        error: new Error(HANDLER_NOT_INITIALIZED),
+                    };
+                }
+                if (message.type === "GET_FEES") {
+                    return {
+                        id: message.id,
+                        tag: TAG,
+                        type: "FEES",
+                        payload: { minerFees: 100 },
+                    };
+                }
+                return null;
+            });
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        const fees = await runtime.getFees();
+
+        expect(fees).toEqual({ minerFees: 100 });
+        expect(serviceWorker.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "INIT_ARKADE_SWAPS" })
+        );
+        const feesCalls = serviceWorker.postMessage.mock.calls.filter(
+            ([msg]: any) => msg.type === "GET_FEES"
+        );
+        expect(feesCalls).toHaveLength(2);
     });
 
     it("throws after exhausting retries", async () => {


### PR DESCRIPTION

  - After a SW restart, the wallet's getStatus ping triggers INITIALIZE_MESSAGE_BUS, which calls start() on every registered handler. ArkadeSwapsMessageHandler.start() only sets
  this.wallet — this.handler stays undefined because that's populated by the page-side INIT_ARKADE_SWAPS message, which has not been re-sent.
  - The first arkade-swaps request after that window (e.g. tapping Receive → Set Amount) reaches handleMessage, hits the !this.handler gate at arkade-swaps-message-handler.ts:742,
  and returns "handler not initialized". ServiceWorkerArkadeSwaps.sendMessageWithRetry was only recovering on MessageBusNotInitializedError, so the error propagated to the page;
  only a reload fixed it.
  - Widen the recoverable predicate in sendMessageWithRetry to also match the handler-half-init error. reinitialize() already sends INIT_ARKADE_SWAPS, which routes through
  handleMessage's INIT_ARKADE_SWAPS branch (above the gate) and runs handleInit, fully restoring this.handler. Next attempt of the user's request succeeds.
  - Add a named constant HANDLER_NOT_INITIALIZED and HandlerNotInitializedError class in arkade-swaps-message-handler.ts, mirroring ts-sdk's MESSAGE_BUS_NOT_INITIALIZED /
  MessageBusNotInitializedError pattern in ts-sdk/src/worker/errors.ts.

  Test plan

  - pnpm test:unit — 298/298 pass
  - New test: retries after re-initializing when SW returns 'ArkadeSwaps handler not initialized' mirrors the existing MessageBus not initialized reinit test and verifies
  INIT_ARKADE_SWAPS is re-sent and the original request succeeds on retry
  - Manual: load wallet PWA, leave tab backgrounded for several minutes, refocus, tap Receive → Edit Amount → Set Amount — should succeed without a page reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service worker error handling to gracefully recover from initialization failures; failed operations now trigger automatic reinitialization and retry instead of failing immediately.
  * Improved reliability of ArkadeSwaps operations when the service worker restarts by implementing recovery logic for handler initialization issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/boltz-swap/pull/145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->